### PR TITLE
fix: normalize OLLAMA_HOST to handle all accepted formats

### DIFF
--- a/src/pytest_llm_rubric/find_local_model.py
+++ b/src/pytest_llm_rubric/find_local_model.py
@@ -15,8 +15,8 @@ import httpx
 from openai import OpenAI
 
 from pytest_llm_rubric.calibration import calibrate
-from pytest_llm_rubric.defaults import OLLAMA_BASE_URL
 from pytest_llm_rubric.plugin import OpenAICompatibleJudge
+from pytest_llm_rubric.utils import parse_ollama_host
 
 
 def _get_ollama_models(base_url: str) -> list[dict]:
@@ -33,7 +33,9 @@ def _size_label(size_bytes: int) -> str:
     return f"{mb:.0f}MB"
 
 
-def find_best_local_model(base_url: str = OLLAMA_BASE_URL) -> None:
+def find_best_local_model(base_url: str | None = None) -> None:
+    if base_url is None:
+        base_url = parse_ollama_host(os.environ.get("OLLAMA_HOST"))
     try:
         models = _get_ollama_models(base_url)
     except Exception as e:
@@ -92,8 +94,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Find the best local model for rubric grading")
     parser.add_argument(
         "--base-url",
-        default=os.environ.get("OLLAMA_HOST", OLLAMA_BASE_URL),
-        help=f"Ollama base URL (default: $OLLAMA_HOST or {OLLAMA_BASE_URL})",
+        default=parse_ollama_host(os.environ.get("OLLAMA_HOST")),
+        help="Ollama base URL (default: $OLLAMA_HOST or http://127.0.0.1:11434)",
     )
     args = parser.parse_args()
     find_best_local_model(args.base_url)

--- a/src/pytest_llm_rubric/plugin.py
+++ b/src/pytest_llm_rubric/plugin.py
@@ -14,10 +14,10 @@ from pytest_llm_rubric.calibration import calibrate
 from pytest_llm_rubric.defaults import (
     ANTHROPIC_BASE_URL,
     ANTHROPIC_MODEL,
-    OLLAMA_BASE_URL,
     OLLAMA_MODEL,
     OPENAI_MODEL,
 )
+from pytest_llm_rubric.utils import parse_ollama_host
 
 ENV_BACKEND = "PYTEST_LLM_RUBRIC_BACKEND"
 ENV_MODEL = "PYTEST_LLM_RUBRIC_MODEL"
@@ -55,7 +55,7 @@ def _discover_ollama() -> OpenAICompatibleJudge | None:
     """Try to connect to a local Ollama instance."""
     import httpx
 
-    base_url = os.environ.get("OLLAMA_HOST", OLLAMA_BASE_URL)
+    base_url = parse_ollama_host(os.environ.get("OLLAMA_HOST"))
     try:
         resp = httpx.get(f"{base_url}/api/tags", timeout=5)
         resp.raise_for_status()

--- a/src/pytest_llm_rubric/utils.py
+++ b/src/pytest_llm_rubric/utils.py
@@ -1,0 +1,39 @@
+"""Anti-corruption layer: normalize external system conventions for internal use."""
+
+from __future__ import annotations
+
+import ipaddress
+import urllib.parse
+
+_OLLAMA_DEFAULT_PORT = 11434
+
+
+def parse_ollama_host(host: str | None) -> str:
+    """Normalize an OLLAMA_HOST value into a full ``scheme://host:port[/path]`` URL.
+
+    Handles the same formats as the Ollama CLI/server: bare hostnames, host:port,
+    scheme://host, :port shorthand, trailing slashes, paths, and IPv6 brackets.
+    """
+    host, port = host or "", _OLLAMA_DEFAULT_PORT
+    scheme, _, hostport = host.partition("://")
+    if not hostport:
+        scheme, hostport = "http", host
+    elif scheme == "http":
+        port = 80
+    elif scheme == "https":
+        port = 443
+
+    split = urllib.parse.urlsplit(f"{scheme}://{hostport}")
+    host = split.hostname or "127.0.0.1"
+    port = split.port or port
+
+    try:
+        if isinstance(ipaddress.ip_address(host), ipaddress.IPv6Address):
+            host = f"[{host}]"
+    except ValueError:
+        ...
+
+    if path := split.path.strip("/"):
+        return f"{scheme}://{host}:{port}/{path}"
+
+    return f"{scheme}://{host}:{port}"

--- a/tests/test_parse_ollama_host.py
+++ b/tests/test_parse_ollama_host.py
@@ -1,0 +1,170 @@
+"""Tests for OLLAMA_HOST parsing/normalization.
+
+Behavior is derived from the ollama Python package's _parse_host function.
+These tests pin the expected behavior so we can implement a clean-room version.
+"""
+
+from __future__ import annotations
+
+from pytest_llm_rubric.utils import parse_ollama_host
+
+
+class TestParseOllamaHostDefaults:
+    """None or empty string should return the default URL."""
+
+    def test_none(self):
+        assert parse_ollama_host(None) == "http://127.0.0.1:11434"
+
+    def test_empty_string(self):
+        assert parse_ollama_host("") == "http://127.0.0.1:11434"
+
+
+class TestParseOllamaHostIPv4:
+    """IPv4 addresses with various formats."""
+
+    def test_ip_only(self):
+        assert parse_ollama_host("1.2.3.4") == "http://1.2.3.4:11434"
+
+    def test_port_only(self):
+        assert parse_ollama_host(":56789") == "http://127.0.0.1:56789"
+
+    def test_ip_and_port(self):
+        assert parse_ollama_host("1.2.3.4:56789") == "http://1.2.3.4:56789"
+
+    def test_http_scheme(self):
+        assert parse_ollama_host("http://1.2.3.4") == "http://1.2.3.4:80"
+
+    def test_https_scheme(self):
+        assert parse_ollama_host("https://1.2.3.4") == "https://1.2.3.4:443"
+
+    def test_https_with_port(self):
+        assert parse_ollama_host("https://1.2.3.4:56789") == "https://1.2.3.4:56789"
+
+
+class TestParseOllamaHostDomain:
+    """Domain names with various formats."""
+
+    def test_domain_only(self):
+        assert parse_ollama_host("example.com") == "http://example.com:11434"
+
+    def test_domain_with_port(self):
+        assert parse_ollama_host("example.com:56789") == "http://example.com:56789"
+
+    def test_http_domain(self):
+        assert parse_ollama_host("http://example.com") == "http://example.com:80"
+
+    def test_https_domain(self):
+        assert parse_ollama_host("https://example.com") == "https://example.com:443"
+
+    def test_https_domain_with_port(self):
+        assert parse_ollama_host("https://example.com:56789") == "https://example.com:56789"
+
+
+class TestParseOllamaHostTrailingSlash:
+    """Trailing slashes should be stripped."""
+
+    def test_domain_trailing_slash(self):
+        assert parse_ollama_host("example.com/") == "http://example.com:11434"
+
+    def test_domain_port_trailing_slash(self):
+        assert parse_ollama_host("example.com:56789/") == "http://example.com:56789"
+
+
+class TestParseOllamaHostWithPath:
+    """URLs with path components should preserve the path (without trailing slash)."""
+
+    def test_domain_with_path(self):
+        assert parse_ollama_host("example.com/path") == "http://example.com:11434/path"
+
+    def test_domain_port_with_path(self):
+        assert parse_ollama_host("example.com:56789/path") == "http://example.com:56789/path"
+
+    def test_https_domain_port_with_path(self):
+        assert (
+            parse_ollama_host("https://example.com:56789/path") == "https://example.com:56789/path"
+        )
+
+    def test_domain_port_path_trailing_slash(self):
+        assert parse_ollama_host("example.com:56789/path/") == "http://example.com:56789/path"
+
+
+class TestParseOllamaHostIPv6:
+    """IPv6 addresses in bracket notation."""
+
+    def test_ipv6_only(self):
+        assert parse_ollama_host("[0001:002:003:0004::1]") == "http://[0001:002:003:0004::1]:11434"
+
+    def test_ipv6_with_port(self):
+        assert (
+            parse_ollama_host("[0001:002:003:0004::1]:56789")
+            == "http://[0001:002:003:0004::1]:56789"
+        )
+
+    def test_http_ipv6(self):
+        assert (
+            parse_ollama_host("http://[0001:002:003:0004::1]") == "http://[0001:002:003:0004::1]:80"
+        )
+
+    def test_https_ipv6(self):
+        assert (
+            parse_ollama_host("https://[0001:002:003:0004::1]")
+            == "https://[0001:002:003:0004::1]:443"
+        )
+
+    def test_https_ipv6_with_port(self):
+        assert (
+            parse_ollama_host("https://[0001:002:003:0004::1]:56789")
+            == "https://[0001:002:003:0004::1]:56789"
+        )
+
+    def test_ipv6_trailing_slash(self):
+        assert parse_ollama_host("[0001:002:003:0004::1]/") == "http://[0001:002:003:0004::1]:11434"
+
+    def test_ipv6_port_trailing_slash(self):
+        assert (
+            parse_ollama_host("[0001:002:003:0004::1]:56789/")
+            == "http://[0001:002:003:0004::1]:56789"
+        )
+
+    def test_ipv6_with_path(self):
+        assert (
+            parse_ollama_host("[0001:002:003:0004::1]/path")
+            == "http://[0001:002:003:0004::1]:11434/path"
+        )
+
+    def test_ipv6_port_with_path(self):
+        assert (
+            parse_ollama_host("[0001:002:003:0004::1]:56789/path")
+            == "http://[0001:002:003:0004::1]:56789/path"
+        )
+
+    def test_https_ipv6_port_with_path(self):
+        assert (
+            parse_ollama_host("https://[0001:002:003:0004::1]:56789/path")
+            == "https://[0001:002:003:0004::1]:56789/path"
+        )
+
+    def test_ipv6_port_path_trailing_slash(self):
+        assert (
+            parse_ollama_host("[0001:002:003:0004::1]:56789/path/")
+            == "http://[0001:002:003:0004::1]:56789/path"
+        )
+
+
+class TestParseOllamaHostLocalhostVariants:
+    """Common localhost variations users might set."""
+
+    def test_localhost(self):
+        assert parse_ollama_host("localhost") == "http://localhost:11434"
+
+    def test_localhost_with_port(self):
+        assert parse_ollama_host("localhost:11434") == "http://localhost:11434"
+
+    def test_http_localhost(self):
+        assert parse_ollama_host("http://localhost:11434") == "http://localhost:11434"
+
+    def test_all_interfaces(self):
+        assert parse_ollama_host("0.0.0.0:11434") == "http://0.0.0.0:11434"
+
+    def test_all_interfaces_no_port(self):
+        assert parse_ollama_host("0.0.0.0") == "http://0.0.0.0:11434"


### PR DESCRIPTION
## Summary

- Add `parse_ollama_host()` in `utils.py` to normalize `OLLAMA_HOST` values into full URLs
- Apply normalization in `plugin.py` and `find_local_model.py`
- 35 unit tests covering IPv4, IPv6, domains, schemes, ports, paths, and trailing slashes

Closes #3

## Test plan

- [x] All 35 `test_parse_ollama_host.py` cases pass
- [x] All existing 59 non-integration tests pass
- [x] Lint and type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
