### PR TITLE
perf: stop calibration early on first failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ line-length = 100
 select = ["E", "F", "I", "UP", "B", "SIM"]
 
 [tool.pytest.ini_options]
+testpaths = ["tests"]
 markers = [
     "integration: tests that require a running LLM backend (Ollama, API keys)",
     "llm_rubric: tests that use the judge_llm fixture (auto-applied by plugin)",

--- a/src/pytest_llm_rubric/calibration.py
+++ b/src/pytest_llm_rubric/calibration.py
@@ -32,18 +32,22 @@ class CalibrationResult:
     total: int
     correct: int
     details: list[dict]
+    stopped_early: bool = False
 
 
 def calibrate(llm: JudgeLLM, system_prompt: str | None = None) -> CalibrationResult:
     """Run golden tests against the LLM and return results.
+
+    Stops early on the first incorrect answer since all tests must pass.
 
     Parameters:
         llm: Any object implementing the JudgeLLM protocol.
         system_prompt: Custom system prompt. Defaults to JUDGE_SYSTEM_PROMPT.
     """
     prompt = system_prompt if system_prompt is not None else JUDGE_SYSTEM_PROMPT
-    details = []
+    details: list[dict] = []
     correct = 0
+    stopped_early = False
 
     for test in GOLDEN_TESTS:
         messages = [
@@ -53,10 +57,12 @@ def calibrate(llm: JudgeLLM, system_prompt: str | None = None) -> CalibrationRes
                 "content": (f"DOCUMENT:\n{test['document']}\n\nCRITERION:\n{test['criterion']}"),
             },
         ]
+        raw_response = ""
         try:
-            response = llm.complete(messages, max_output_tokens=16).strip().upper()
-            m = _VERDICT_RE.match(response)
-            verdict = m.group(1) if m else f"INVALID: {response[:50]}"
+            raw_response = llm.complete(messages, max_output_tokens=16).strip()
+            normalized = raw_response.upper()
+            m = _VERDICT_RE.match(normalized)
+            verdict = m.group(1) if m else f"INVALID: {normalized[:50]}"
         except Exception as e:
             verdict = f"ERROR: {e}"
 
@@ -70,12 +76,18 @@ def calibrate(llm: JudgeLLM, system_prompt: str | None = None) -> CalibrationRes
                 "expected": test["expected"],
                 "actual": verdict,
                 "correct": is_correct,
+                "raw_response": raw_response,
             }
         )
+
+        if not is_correct:
+            stopped_early = len(details) < len(GOLDEN_TESTS)
+            break
 
     return CalibrationResult(
         passed=correct == len(GOLDEN_TESTS),
         total=len(GOLDEN_TESTS),
         correct=correct,
         details=details,
+        stopped_early=stopped_early,
     )

--- a/src/pytest_llm_rubric/find_local_model.py
+++ b/src/pytest_llm_rubric/find_local_model.py
@@ -2,6 +2,8 @@
 
 Usage:
     uv run python -m pytest_llm_rubric.find_local_model
+    uv run python -m pytest_llm_rubric.find_local_model qwen3.5:27b
+    uv run python -m pytest_llm_rubric.find_local_model granite4:3b lfm2:24b --verbose
     uv run python -m pytest_llm_rubric.find_local_model --base-url http://host:11434
 """
 
@@ -33,29 +35,47 @@ def _size_label(size_bytes: int) -> str:
     return f"{mb:.0f}MB"
 
 
-def find_best_local_model(base_url: str | None = None) -> None:
+def find_best_local_model(
+    base_url: str | None = None,
+    *,
+    verbose: bool = False,
+    model_names: list[str] | None = None,
+) -> None:
     if base_url is None:
         base_url = parse_ollama_host(os.environ.get("OLLAMA_HOST"))
     try:
-        models = _get_ollama_models(base_url)
+        all_models = _get_ollama_models(base_url)
     except Exception as e:
         print(f"Could not connect to Ollama at {base_url}: {e}")
         sys.exit(1)
 
-    if not models:
+    if not all_models:
         print("No models found in Ollama.")
         sys.exit(1)
 
-    # Sort by size ascending (smallest first)
-    models.sort(key=lambda m: m.get("size", 0))
+    available = {m["name"]: m for m in all_models}
 
-    # Filter out non-generative models
-    skip_patterns = ("embed", "vision", "clip", "whisper")
-    all_count = len(models)
-    models = [m for m in models if not any(p in m["name"].lower() for p in skip_patterns)]
-    skipped = all_count - len(models)
-    if skipped:
-        print(f"Skipped {skipped} non-generative model(s) (embedding/vision/etc.).")
+    if model_names:
+        # Use only the specified models, in the order given
+        models = []
+        for name in model_names:
+            if name in available:
+                models.append(available[name])
+            else:
+                avail = ", ".join(sorted(available))
+                print(f"Model {name!r} not found in Ollama. Available: {avail}")
+                sys.exit(1)
+    else:
+        # Sort by size ascending (smallest first)
+        models = sorted(all_models, key=lambda m: m.get("size", 0))
+
+        # Filter out non-generative models
+        skip_patterns = ("embed", "vision", "clip", "whisper")
+        all_count = len(models)
+        models = [m for m in models if not any(p in m["name"].lower() for p in skip_patterns)]
+        skipped = all_count - len(models)
+        if skipped:
+            print(f"Skipped {skipped} non-generative model(s) (embedding/vision/etc.).")
 
     print(f"Found {len(models)} model(s) in Ollama. Running calibration...\n")
 
@@ -68,15 +88,23 @@ def find_best_local_model(base_url: str | None = None) -> None:
         size = _size_label(model.get("size", 0))
         print(f"  {name:<30} ({size:>6}) ... ", end="", flush=True)
 
-        judge = OpenAICompatibleJudge(client, name)
+        judge = OpenAICompatibleJudge(client, name, use_legacy_max_tokens=True)
 
         try:
             result = calibrate(judge)
-            status = f"{'PASS' if result.passed else 'FAIL'} ({result.correct}/{result.total})"
+            label = "PASS" if result.passed else "FAIL"
+            tested = len(result.details)
+            early = f" stopped at {tested}/{result.total}" if result.stopped_early else ""
+            status = f"{label} ({result.correct}/{result.total}{early})"
             print(status)
             results.append({"name": name, "size": size, "result": result})
             if result.passed and recommended is None:
                 recommended = name
+            if verbose:
+                for d in result.details:
+                    mark = "OK" if d["correct"] else "NG"
+                    raw = d.get("raw_response", "")
+                    print(f"    [{mark}] expected={d['expected']:<4}  raw={raw!r}")
         except Exception as e:
             print(f"ERROR: {e}")
 
@@ -93,9 +121,24 @@ def find_best_local_model(base_url: str | None = None) -> None:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Find the best local model for rubric grading")
     parser.add_argument(
+        "models",
+        nargs="*",
+        help="Specific model name(s) to test (default: all available models)",
+    )
+    parser.add_argument(
         "--base-url",
         default=parse_ollama_host(os.environ.get("OLLAMA_HOST")),
         help=f"Ollama base URL (default: $OLLAMA_HOST or http://{OLLAMA_DEFAULT_HOST}:{OLLAMA_DEFAULT_PORT})",
     )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show raw LLM responses for each calibration test",
+    )
     args = parser.parse_args()
-    find_best_local_model(args.base_url)
+    find_best_local_model(
+        args.base_url,
+        verbose=args.verbose,
+        model_names=args.models or None,
+    )

--- a/src/pytest_llm_rubric/plugin.py
+++ b/src/pytest_llm_rubric/plugin.py
@@ -157,8 +157,13 @@ def _calibrate_or_skip(judge: JudgeLLM) -> JudgeLLM:
     result = calibrate(judge)
     if not result.passed:
         failures = [d for d in result.details if not d["correct"]]
-        msg = f"LLM backend failed calibration ({result.correct}/{result.total}).\n" + "\n".join(
-            f"  {f['criterion']}: expected {f['expected']}, got {f['actual']}" for f in failures
+        tested = len(result.details)
+        suffix = f" (stopped early after {tested}/{result.total})" if result.stopped_early else ""
+        msg = (
+            f"LLM backend failed calibration ({result.correct}/{result.total}){suffix}.\n"
+            + "\n".join(
+                f"  {f['criterion']}: expected {f['expected']}, got {f['actual']}" for f in failures
+            )
         )
         pytest.skip(msg)
     return judge

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -42,10 +42,12 @@ class TestCalibrate:
         result = calibrate(FakeLLM("PASS"))
         assert result.passed is False
         assert result.correct < result.total
+        assert result.stopped_early is True
 
     def test_result_has_details(self):
         result = calibrate(FakeLLM("PASS"))
-        assert len(result.details) == result.total
+        assert len(result.details) <= result.total
+        assert len(result.details) > 0
         for detail in result.details:
             assert "criterion" in detail
             assert "expected" in detail
@@ -107,3 +109,18 @@ class TestCalibrate:
         result = calibrate(llm)
         assert result.passed is True
         assert llm.captured_prompts[0] == JUDGE_SYSTEM_PROMPT
+
+    def test_early_stop_on_first_failure(self):
+        """Calibration stops at the first incorrect answer."""
+        result = calibrate(FakeLLM("FAIL"))
+        # FakeLLM("FAIL") gets the first test wrong (expected PASS),
+        # so it should stop after 1 test.
+        assert result.stopped_early is True
+        assert len(result.details) == 1
+        assert result.correct == 0
+
+    def test_no_early_stop_on_perfect(self):
+        """Perfect judge runs all tests without early stopping."""
+        result = calibrate(ReplayLLM())
+        assert result.stopped_early is False
+        assert len(result.details) == result.total


### PR DESCRIPTION
## Summary

- **Early stopping**: Calibration now stops at the first incorrect answer. Since all 12/12 must pass, continuing after a failure wastes time (6+ minutes on CPU with slow models).
- **find_local_model.py bug fix**: Add missing `use_legacy_max_tokens=True` for Ollama, which was causing `max_completion_tokens` to be sent instead of `max_tokens`.
- **find_local_model.py diagnostics**: Add `--verbose` flag showing raw LLM responses and positional args to test specific models (e.g. `find_local_model qwen3.5:9b ministral-3:8b -v`).
- **Raw response tracking**: `CalibrationResult.details` now includes `raw_response` for debugging model output issues.

## Test plan

- [x] All 13 unit tests pass (`uv run pytest -m "not integration"`)
- [x] New tests: `test_early_stop_on_first_failure`, `test_no_early_stop_on_perfect`
- [x] Existing tests updated for early stopping behavior
- [x] Manual: `uv run python -m pytest_llm_rubric.find_local_model <model> -v` shows early stop info

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
