### PR TITLE
fix: retry on empty LLM response

### DIFF
--- a/src/pytest_llm_rubric/plugin.py
+++ b/src/pytest_llm_rubric/plugin.py
@@ -48,6 +48,8 @@ class AnyLLMJudge:
         self._api_base = api_base
         self._api_key = api_key
 
+    _MAX_EMPTY_RETRIES = 2
+
     def complete(self, messages: list[dict[str, Any]], max_output_tokens: int = 256) -> str:
         from any_llm import completion
         from any_llm.types.completion import ChatCompletion
@@ -65,8 +67,18 @@ class AnyLLMJudge:
         if self._api_key is not None:
             kwargs["api_key"] = self._api_key
 
-        response = cast(ChatCompletion, completion(**kwargs))
-        return response.choices[0].message.content or ""
+        for attempt in range(1 + self._MAX_EMPTY_RETRIES):
+            response = cast(ChatCompletion, completion(**kwargs))
+            content = response.choices[0].message.content or ""
+            if content:
+                return content
+            if attempt < self._MAX_EMPTY_RETRIES:
+                warnings.warn(
+                    f"Empty response from {self._model} "
+                    f"(attempt {attempt + 1}/{1 + self._MAX_EMPTY_RETRIES}), retrying.",
+                    stacklevel=2,
+                )
+        return ""
 
 
 def _discover_ollama() -> AnyLLMJudge | None:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -105,6 +105,40 @@ class TestAnyLLMJudge:
 
         assert "api_base" not in mock_comp.call_args.kwargs
 
+    def test_complete_retries_on_empty_response(self):
+        """Empty responses are retried up to _MAX_EMPTY_RETRIES times."""
+        empty = MagicMock(choices=[MagicMock(message=MagicMock(content=""))])
+        ok = MagicMock(choices=[MagicMock(message=MagicMock(content="PASS"))])
+
+        with patch("any_llm.completion", side_effect=[empty, ok]) as mock_comp:
+            judge = AnyLLMJudge("m", "ollama", api_base="http://localhost:11434")
+            result = judge.complete([{"role": "user", "content": "hi"}])
+
+        assert result == "PASS"
+        assert mock_comp.call_count == 2
+
+    def test_complete_returns_empty_after_all_retries_exhausted(self):
+        """Returns empty string when all retries produce empty responses."""
+        empty = MagicMock(choices=[MagicMock(message=MagicMock(content=""))])
+
+        with patch("any_llm.completion", return_value=empty) as mock_comp:
+            judge = AnyLLMJudge("m", "ollama", api_base="http://localhost:11434")
+            result = judge.complete([{"role": "user", "content": "hi"}])
+
+        assert result == ""
+        assert mock_comp.call_count == 1 + AnyLLMJudge._MAX_EMPTY_RETRIES
+
+    def test_complete_no_retry_on_nonempty_response(self):
+        """Non-empty responses are returned immediately without retry."""
+        ok = MagicMock(choices=[MagicMock(message=MagicMock(content="FAIL"))])
+
+        with patch("any_llm.completion", return_value=ok) as mock_comp:
+            judge = AnyLLMJudge("m", "openai", api_key="k")
+            result = judge.complete([{"role": "user", "content": "hi"}])
+
+        assert result == "FAIL"
+        assert mock_comp.call_count == 1
+
 
 # ---------------------------------------------------------------------------
 # Fixture tests (using pytester for isolation)


### PR DESCRIPTION
## Summary

- Retry empty LLM responses up to 2 times in `AnyLLMJudge.complete()` to handle intermittent Ollama failures
- Emit `warnings.warn()` on each retry for observability
- Add 3 unit tests covering retry success, retry exhaustion, and no-retry paths

Addresses the empty response category from #9 (nemotron-3-nano:4b 2/5 fail, qwen3.5:9b 1/20 fail).

## Test plan

- [x] All existing tests pass (`uv run pytest -m "not integration"` — 66 passed)
- [x] Ruff lint clean
- [x] Run stability test against affected models to verify reduced empty response rate
- [x] Integration test with live Ollama

🤖 Generated with [Claude Code](https://claude.com/claude-code)
