### PR TITLE
feat!: use structured output for calibration judgments

### DIFF
--- a/src/pytest_llm_rubric/__init__.py
+++ b/src/pytest_llm_rubric/__init__.py
@@ -6,10 +6,14 @@
 
 
 def __getattr__(name: str):  # noqa: ANN001
-    if name in ("CalibrationResult", "calibrate"):
-        from pytest_llm_rubric.calibration import CalibrationResult, calibrate
+    if name in ("CalibrationResult", "Verdict", "calibrate"):
+        from pytest_llm_rubric.calibration import CalibrationResult, Verdict, calibrate
 
-        _exports = {"CalibrationResult": CalibrationResult, "calibrate": calibrate}
+        _exports = {
+            "CalibrationResult": CalibrationResult,
+            "Verdict": Verdict,
+            "calibrate": calibrate,
+        }
         return _exports[name]
     if name in ("JudgeLLM", "AnyLLMJudge"):
         from pytest_llm_rubric.plugin import AnyLLMJudge, JudgeLLM
@@ -23,5 +27,6 @@ __all__ = [
     "AnyLLMJudge",
     "CalibrationResult",
     "JudgeLLM",
+    "Verdict",
     "calibrate",
 ]

--- a/src/pytest_llm_rubric/calibration.py
+++ b/src/pytest_llm_rubric/calibration.py
@@ -6,9 +6,12 @@ If the backend fails to match expected verdicts, it is considered unreliable.
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel
 
 from pytest_llm_rubric.golden_tests import GOLDEN_TESTS
 
@@ -18,6 +21,26 @@ if TYPE_CHECKING:
 # Accepts "PASS" / "FAIL" after optional non-word prefix (markdown, punctuation, whitespace).
 # \b prevents partial matches like "PASSING" or "FAILED".
 _VERDICT_RE = re.compile(r"\W*(PASS|FAIL)\b")
+
+
+class Verdict(BaseModel):
+    """Structured output schema for rubric judgments."""
+
+    result: Literal["PASS", "FAIL"]
+
+
+def _parse_verdict(raw: str) -> str:
+    """Extract PASS/FAIL from a response, trying JSON first then regex."""
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict) and data.get("result") in ("PASS", "FAIL"):
+            return data["result"]
+    except (json.JSONDecodeError, TypeError):
+        pass
+    normalized = raw.upper()
+    m = _VERDICT_RE.match(normalized)
+    return m.group(1) if m else f"INVALID: {normalized[:50]}"
+
 
 JUDGE_SYSTEM_PROMPT = """\
 You are a rubric grader. You will be given a DOCUMENT and a CRITERION.
@@ -59,10 +82,10 @@ def calibrate(llm: JudgeLLM, system_prompt: str | None = None) -> CalibrationRes
         ]
         raw_response = ""
         try:
-            raw_response = llm.complete(messages, max_output_tokens=16).strip()
-            normalized = raw_response.upper()
-            m = _VERDICT_RE.match(normalized)
-            verdict = m.group(1) if m else f"INVALID: {normalized[:50]}"
+            raw_response = llm.complete(
+                messages, max_output_tokens=16, response_format=Verdict
+            ).strip()
+            verdict = _parse_verdict(raw_response)
         except Exception as e:
             verdict = f"ERROR: {e}"
 

--- a/src/pytest_llm_rubric/plugin.py
+++ b/src/pytest_llm_rubric/plugin.py
@@ -29,7 +29,12 @@ def _resolve_model(env_var: str, default: str) -> str:
 class JudgeLLM(Protocol):
     """Protocol for LLM backends. Override the judge_llm fixture to provide your own."""
 
-    def complete(self, messages: list[dict[str, Any]], max_output_tokens: int = 256) -> str: ...
+    def complete(
+        self,
+        messages: list[dict[str, Any]],
+        max_output_tokens: int = 256,
+        response_format: type | None = None,
+    ) -> str: ...
 
 
 class AnyLLMJudge:
@@ -50,7 +55,12 @@ class AnyLLMJudge:
 
     _MAX_EMPTY_RETRIES = 2
 
-    def complete(self, messages: list[dict[str, Any]], max_output_tokens: int = 256) -> str:
+    def complete(
+        self,
+        messages: list[dict[str, Any]],
+        max_output_tokens: int = 256,
+        response_format: type | None = None,
+    ) -> str:
         from any_llm import completion
         from any_llm.types.completion import ChatCompletion
 
@@ -66,6 +76,8 @@ class AnyLLMJudge:
             kwargs["api_base"] = self._api_base
         if self._api_key is not None:
             kwargs["api_key"] = self._api_key
+        if response_format is not None:
+            kwargs["response_format"] = response_format
 
         for attempt in range(1 + self._MAX_EMPTY_RETRIES):
             response = cast(ChatCompletion, completion(**kwargs))

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from pytest_llm_rubric.calibration import GOLDEN_TESTS, JUDGE_SYSTEM_PROMPT, calibrate
+from pytest_llm_rubric.calibration import (
+    GOLDEN_TESTS,
+    JUDGE_SYSTEM_PROMPT,
+    _parse_verdict,
+    calibrate,
+)
 
 
 class FakeLLM:
@@ -13,7 +18,12 @@ class FakeLLM:
     def __init__(self, response: str):
         self._response = response
 
-    def complete(self, messages: list[dict], max_output_tokens: int = 256) -> str:
+    def complete(
+        self,
+        messages: list[dict],
+        max_output_tokens: int = 256,
+        response_format: type | None = None,
+    ) -> str:
         return self._response
 
 
@@ -25,7 +35,12 @@ class ReplayLLM:
         self._transform = transform
         self.captured_prompts: list[str] = []
 
-    def complete(self, messages: list[dict], max_output_tokens: int = 256) -> str:
+    def complete(
+        self,
+        messages: list[dict],
+        max_output_tokens: int = 256,
+        response_format: type | None = None,
+    ) -> str:
         self.captured_prompts.append(messages[0]["content"])
         expected = GOLDEN_TESTS[self._index]["expected"]
         self._index += 1
@@ -124,3 +139,36 @@ class TestCalibrate:
         result = calibrate(ReplayLLM())
         assert result.stopped_early is False
         assert len(result.details) == result.total
+
+    def test_json_verdict_accepted(self):
+        """Structured JSON output is parsed correctly."""
+        import json
+
+        def to_json(verdict: str) -> str:
+            return json.dumps({"result": verdict})
+
+        result = calibrate(ReplayLLM(transform=to_json))
+        assert result.passed is True
+
+
+class TestParseVerdict:
+    def test_json_pass(self):
+        assert _parse_verdict('{"result": "PASS"}') == "PASS"
+
+    def test_json_fail(self):
+        assert _parse_verdict('{"result": "FAIL"}') == "FAIL"
+
+    def test_freetext_pass(self):
+        assert _parse_verdict("PASS") == "PASS"
+
+    def test_freetext_fail(self):
+        assert _parse_verdict("FAIL") == "FAIL"
+
+    def test_decorated_freetext(self):
+        assert _parse_verdict("**PASS**") == "PASS"
+
+    def test_invalid(self):
+        assert _parse_verdict("JUNK").startswith("INVALID")
+
+    def test_empty(self):
+        assert _parse_verdict("").startswith("INVALID")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -105,6 +105,33 @@ class TestAnyLLMJudge:
 
         assert "api_base" not in mock_comp.call_args.kwargs
 
+    def test_complete_forwards_response_format(self):
+        """response_format is forwarded to any_llm.completion()."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content='{"result": "PASS"}'))]
+
+        from pydantic import BaseModel
+
+        class MyFormat(BaseModel):
+            result: str
+
+        with patch("any_llm.completion", return_value=mock_response) as mock_comp:
+            judge = AnyLLMJudge("m", "openai", api_key="k")
+            judge.complete([{"role": "user", "content": "hi"}], response_format=MyFormat)
+
+        assert mock_comp.call_args.kwargs["response_format"] is MyFormat
+
+    def test_complete_omits_none_response_format(self):
+        """response_format is not passed when None."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="PASS"))]
+
+        with patch("any_llm.completion", return_value=mock_response) as mock_comp:
+            judge = AnyLLMJudge("m", "openai", api_key="k")
+            judge.complete([{"role": "user", "content": "hi"}])
+
+        assert "response_format" not in mock_comp.call_args.kwargs
+
     def test_complete_retries_on_empty_response(self):
         """Empty responses are retried up to _MAX_EMPTY_RETRIES times."""
         empty = MagicMock(choices=[MagicMock(message=MagicMock(content=""))])
@@ -152,7 +179,7 @@ _FAKE_JUDGE_CONFTEST = """
 import pytest
 
 class FakeLLM:
-    def complete(self, messages, max_output_tokens=256):
+    def complete(self, messages, max_output_tokens=256, response_format=None):
         return "fake"
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary

- Use structured output (Pydantic `response_format`) for calibration judgments, improving reliability for models with messy free-text output
- Add `Verdict` model and `_parse_verdict()` with JSON-first, regex-fallback parsing
- Add `response_format` parameter to `JudgeLLM` Protocol and `AnyLLMJudge.complete()`
- Export `Verdict` from package public API

### Stability test results (structured vs free-text)

| Model | Free-text | Structured |
|---|---|---|
| gpt-oss:20b | 11-12/12 | **12/12 (10/10 runs)** |
| ministral-3:8b | 10-11/12 | **12/12** |
| phi4-mini-reasoning:3.8b | 6-9/12 | **8-9/12** |
| qwen3.5:2b | 11-12/12 | 11-12/12 |

Related: #9

## Breaking change

`JudgeLLM.complete()` now accepts a `response_format` parameter. Custom implementations must add `response_format: type | None = None` to their `complete()` signature.

## Test plan

- [x] All unit tests pass (77 passed)
- [x] All integration tests pass (80 passed, Ollama + Anthropic + OpenAI)
- [x] Ruff lint and format clean
- [x] Verify in downstream project (agent-guild-tavern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
