### PR TITLE
fix: fail instead of skip when explicit backend is unavailable

### DIFF
--- a/src/pytest_llm_rubric/plugin.py
+++ b/src/pytest_llm_rubric/plugin.py
@@ -156,28 +156,28 @@ def _default_judge_llm() -> JudgeLLM:
     if backend == "openai":
         if (judge := _discover_openai()) is not None:
             return judge
-        pytest.skip("PYTEST_LLM_RUBRIC_BACKEND=openai but OPENAI_API_KEY is not set.")
+        pytest.fail("PYTEST_LLM_RUBRIC_BACKEND=openai but OPENAI_API_KEY is not set.")
 
     elif backend == "anthropic":
         if (judge := _discover_anthropic()) is not None:
             return judge
-        pytest.skip("PYTEST_LLM_RUBRIC_BACKEND=anthropic but ANTHROPIC_API_KEY is not set.")
+        pytest.fail("PYTEST_LLM_RUBRIC_BACKEND=anthropic but ANTHROPIC_API_KEY is not set.")
 
     elif backend == "ollama" or backend == "":
         if (judge := _discover_ollama()) is not None:
             return judge
         if backend == "ollama":
-            pytest.skip("PYTEST_LLM_RUBRIC_BACKEND=ollama but Ollama is not running.")
+            pytest.fail("PYTEST_LLM_RUBRIC_BACKEND=ollama but Ollama is not running.")
         pytest.skip("No LLM backend available. Run Ollama or set PYTEST_LLM_RUBRIC_BACKEND.")
 
     elif backend == "auto":
         for discover in (_discover_ollama, _discover_anthropic, _discover_openai):
             if (judge := discover()) is not None:
                 return judge
-        pytest.skip("PYTEST_LLM_RUBRIC_BACKEND=auto but no backend found.")
+        pytest.fail("PYTEST_LLM_RUBRIC_BACKEND=auto but no backend found.")
 
     else:
-        pytest.skip(f"Unknown PYTEST_LLM_RUBRIC_BACKEND: {backend!r}")
+        pytest.fail(f"Unknown PYTEST_LLM_RUBRIC_BACKEND: {backend!r}")
 
 
 def _calibrate_or_skip(judge: JudgeLLM) -> JudgeLLM:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -224,7 +224,40 @@ class TestJudgeLLMFixture:
         result = pytester.runpytest_subprocess("-v")
         result.assert_outcomes(passed=1)
 
-    def test_unknown_backend_skips(self, pytester, monkeypatch):
+    def test_explicit_ollama_fails_when_unavailable(self, pytester, monkeypatch):
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "ollama")
+        monkeypatch.setenv("OLLAMA_HOST", "http://localhost:19999")
+        pytester.makeconftest("")
+        pytester.makepyfile("""
+            def test_uses_judge(judge_llm):
+                assert judge_llm is not None
+        """)
+        result = pytester.runpytest_subprocess("-v")
+        result.assert_outcomes(errors=1)
+
+    def test_explicit_openai_fails_without_key(self, pytester, monkeypatch):
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "openai")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        pytester.makeconftest("")
+        pytester.makepyfile("""
+            def test_uses_judge(judge_llm):
+                assert judge_llm is not None
+        """)
+        result = pytester.runpytest_subprocess("-v")
+        result.assert_outcomes(errors=1)
+
+    def test_explicit_anthropic_fails_without_key(self, pytester, monkeypatch):
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "anthropic")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        pytester.makeconftest("")
+        pytester.makepyfile("""
+            def test_uses_judge(judge_llm):
+                assert judge_llm is not None
+        """)
+        result = pytester.runpytest_subprocess("-v")
+        result.assert_outcomes(errors=1)
+
+    def test_unknown_backend_fails(self, pytester, monkeypatch):
         monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "bogus")
         pytester.makeconftest("")
         pytester.makepyfile("""
@@ -232,7 +265,7 @@ class TestJudgeLLMFixture:
                 assert judge_llm is not None
         """)
         result = pytester.runpytest_subprocess("-v")
-        result.assert_outcomes(skipped=1)
+        result.assert_outcomes(errors=1)
 
     def test_llm_rubric_marker_auto_applied(self, pytester):
         pytester.makeconftest(_FAKE_JUDGE_CONFTEST)


### PR DESCRIPTION
## Summary
- When `PYTEST_LLM_RUBRIC_BACKEND` is explicitly set (e.g. `openai`, `anthropic`, `ollama`, `auto`) but the backend is unavailable, tests now **fail** instead of silently skipping
- Skip behavior preserved only for the default (empty) case where no backend is assumed
- Added pytester tests for each explicit backend failure case

Closes #12

## Test plan
- [x] Existing tests updated and passing (24/24)
- [x] New tests: `test_explicit_ollama_fails_when_unavailable`, `test_explicit_openai_fails_without_key`, `test_explicit_anthropic_fails_without_key`
- [x] `test_unknown_backend_fails` updated (was `test_unknown_backend_skips`)
- [x] Default (empty) backend still skips — `test_skip_when_no_backend` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)