### PR TITLE
refactor: audit and fix naming/behavior consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ def test_mentions_deadline(judge_llm):
 
 1. **Discover** — auto-detect available backends based on installed extras and env vars
 2. **Preflight** — verify the discovered backend can reliably judge PASS/FAIL before exposing it as `judge_llm` (skippable)
-3. **Provide or skip** — expose the `judge_llm` session fixture on success, or skip dependent tests if no backend is found or preflight fails
+3. **Provide, skip, or fail** — expose the `judge_llm` session fixture on success. If the default (empty) backend is unavailable or preflight fails, dependent tests are skipped. If an explicit backend is unavailable, tests fail
 
 Paid cloud APIs never run unless explicitly configured.
 
@@ -104,7 +104,7 @@ Each backend requires its corresponding extra:
 | `auto` | any of the above | — |
 
 `auto` tries Ollama → Anthropic → OpenAI, using the first available.
-If no backend is found or preflight fails, dependent tests are skipped (not failed).
+If the default (empty) backend is unavailable or preflight fails, dependent tests are skipped. If an explicit backend (`ollama`, `anthropic`, `openai`, `auto`) is set but unavailable, tests **fail** to surface CI misconfigurations.
 
 CI example:
 

--- a/src/pytest_llm_rubric/plugin.py
+++ b/src/pytest_llm_rubric/plugin.py
@@ -19,6 +19,10 @@ from pytest_llm_rubric.utils import parse_ollama_host
 ENV_BACKEND = "PYTEST_LLM_RUBRIC_BACKEND"
 ENV_MODEL = "PYTEST_LLM_RUBRIC_MODEL"
 ENV_SKIP_PREFLIGHT = "PYTEST_LLM_RUBRIC_SKIP_PREFLIGHT"
+ENV_OLLAMA_MODEL = "PYTEST_LLM_RUBRIC_OLLAMA_MODEL"
+ENV_ANTHROPIC_MODEL = "PYTEST_LLM_RUBRIC_ANTHROPIC_MODEL"
+ENV_ANTHROPIC_BASE_URL = "PYTEST_LLM_RUBRIC_ANTHROPIC_BASE_URL"
+ENV_OPENAI_MODEL = "PYTEST_LLM_RUBRIC_OPENAI_MODEL"
 
 
 def _resolve_model(env_var: str, default: str) -> str:
@@ -105,7 +109,7 @@ def _discover_ollama() -> AnyLLMJudge | None:
         if not models:
             return None
         available = {m["name"] for m in models}
-        requested = _resolve_model("PYTEST_LLM_RUBRIC_OLLAMA_MODEL", OLLAMA_MODEL or "")
+        requested = _resolve_model(ENV_OLLAMA_MODEL, OLLAMA_MODEL or "")
         if requested and requested in available:
             model_name = requested
         elif requested and requested not in available:
@@ -127,8 +131,8 @@ def _discover_anthropic() -> AnyLLMJudge | None:
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
         return None
-    model = _resolve_model("PYTEST_LLM_RUBRIC_ANTHROPIC_MODEL", ANTHROPIC_MODEL)
-    api_base = os.environ.get("PYTEST_LLM_RUBRIC_ANTHROPIC_BASE_URL")
+    model = _resolve_model(ENV_ANTHROPIC_MODEL, ANTHROPIC_MODEL)
+    api_base = os.environ.get(ENV_ANTHROPIC_BASE_URL)
     return AnyLLMJudge(model, "anthropic", api_key=api_key, api_base=api_base)
 
 
@@ -137,7 +141,7 @@ def _discover_openai() -> AnyLLMJudge | None:
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         return None
-    model = _resolve_model("PYTEST_LLM_RUBRIC_OPENAI_MODEL", OPENAI_MODEL)
+    model = _resolve_model(ENV_OPENAI_MODEL, OPENAI_MODEL)
     return AnyLLMJudge(model, "openai", api_key=api_key)
 
 
@@ -146,10 +150,13 @@ def _default_judge_llm() -> JudgeLLM:
 
     Controlled by PYTEST_LLM_RUBRIC_BACKEND:
       (unset)    - try Ollama only, skip if unavailable
-      auto       - try Ollama, then Anthropic, then OpenAI
-      ollama     - Ollama only
-      anthropic  - Anthropic API only
-      openai     - OpenAI API only
+      auto       - try Ollama → Anthropic → OpenAI; fail if none found
+      ollama     - Ollama only; fail if unavailable
+      anthropic  - Anthropic API only; fail if unavailable
+      openai     - OpenAI API only; fail if unavailable
+
+    Explicit backends fail (pytest.fail) instead of skip so that CI
+    misconfigurations surface as errors rather than silent skips.
     """
     backend = os.environ.get(ENV_BACKEND, "").lower()
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -227,6 +227,7 @@ class TestJudgeLLMFixture:
     def test_explicit_ollama_fails_when_unavailable(self, pytester, monkeypatch):
         monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "ollama")
         monkeypatch.setenv("OLLAMA_HOST", "http://localhost:19999")
+        monkeypatch.setenv("PYTHONUTF8", "1")
         pytester.makeconftest("")
         pytester.makepyfile("""
             def test_uses_judge(judge_llm):
@@ -238,6 +239,7 @@ class TestJudgeLLMFixture:
     def test_explicit_openai_fails_without_key(self, pytester, monkeypatch):
         monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "openai")
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("PYTHONUTF8", "1")
         pytester.makeconftest("")
         pytester.makepyfile("""
             def test_uses_judge(judge_llm):
@@ -249,6 +251,7 @@ class TestJudgeLLMFixture:
     def test_explicit_anthropic_fails_without_key(self, pytester, monkeypatch):
         monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "anthropic")
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("PYTHONUTF8", "1")
         pytester.makeconftest("")
         pytester.makepyfile("""
             def test_uses_judge(judge_llm):
@@ -259,6 +262,7 @@ class TestJudgeLLMFixture:
 
     def test_unknown_backend_fails(self, pytester, monkeypatch):
         monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "bogus")
+        monkeypatch.setenv("PYTHONUTF8", "1")
         pytester.makeconftest("")
         pytester.makepyfile("""
             def test_uses_judge(judge_llm):


### PR DESCRIPTION
## Summary
- Consolidate all env var names as module-level constants in `plugin.py` — no more hardcoded strings scattered across discovery functions
- Update `_default_judge_llm()` docstring to document fail vs skip behavior for explicit vs default backends
- Fix README to clarify that explicit backends fail (not skip) when unavailable, reflecting the #12 behavior change
- Fix pytester subprocess tests on Windows by setting `PYTHONUTF8=1` to avoid Shift-JIS encoding issues in `pytest.fail()` output

Closes #14

## Test plan
- [x] All 80 tests pass (76 passed + 4 pytester subprocess tests now fixed with PYTHONUTF8)
- [x] Ruff lint clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
