### PR TITLE
fix: surface discovery failure reasons in skip/fail messages

### DIFF
--- a/src/pytest_llm_rubric/plugin.py
+++ b/src/pytest_llm_rubric/plugin.py
@@ -96,16 +96,16 @@ class AnyLLMJudge:
         return ""
 
 
-def _discover_ollama() -> AnyLLMJudge | None:
-    """Try to connect to a local Ollama instance."""
+def _discover_ollama() -> AnyLLMJudge | str:
+    """Try to connect to a local Ollama instance.
+
+    Returns an ``AnyLLMJudge`` on success, or a human-readable reason string
+    explaining why discovery failed.
+    """
     try:
         import ollama as _ollama  # noqa: F401
     except ImportError:
-        warnings.warn(
-            "ollama package is not installed. Install with: pip install 'any-llm-sdk[ollama]'",
-            stacklevel=2,
-        )
-        return None
+        return "ollama package is not installed."
 
     import httpx
 
@@ -115,40 +115,44 @@ def _discover_ollama() -> AnyLLMJudge | None:
         resp.raise_for_status()
         models = resp.json().get("models", [])
         if not models:
-            return None
+            return "Ollama is running but has no models installed."
         available = {m["name"] for m in models}
         requested = _resolve_model(ENV_OLLAMA_MODEL, OLLAMA_MODEL or "")
         if requested and requested in available:
             model_name = requested
         elif requested and requested not in available:
-            warnings.warn(
+            return (
                 f"Requested Ollama model {requested!r} not found. "
-                f"Available: {', '.join(sorted(available))}.",
-                stacklevel=2,
+                f"Available: {', '.join(sorted(available))}."
             )
-            return None
         else:
             model_name = models[0]["name"]
         return AnyLLMJudge(model_name, "ollama", api_base=base_url)
     except Exception:
-        return None
+        return f"Could not connect to Ollama at {base_url}."
 
 
-def _discover_anthropic() -> AnyLLMJudge | None:
-    """Use Anthropic API if ANTHROPIC_API_KEY is set."""
+def _discover_anthropic() -> AnyLLMJudge | str:
+    """Use Anthropic API if ANTHROPIC_API_KEY is set.
+
+    Returns an ``AnyLLMJudge`` on success, or a reason string on failure.
+    """
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
-        return None
+        return "ANTHROPIC_API_KEY is not set."
     model = _resolve_model(ENV_ANTHROPIC_MODEL, ANTHROPIC_MODEL)
     api_base = os.environ.get(ENV_ANTHROPIC_BASE_URL)
     return AnyLLMJudge(model, "anthropic", api_key=api_key, api_base=api_base)
 
 
-def _discover_openai() -> AnyLLMJudge | None:
-    """Use OpenAI API if OPENAI_API_KEY is set."""
+def _discover_openai() -> AnyLLMJudge | str:
+    """Use OpenAI API if OPENAI_API_KEY is set.
+
+    Returns an ``AnyLLMJudge`` on success, or a reason string on failure.
+    """
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
-        return None
+        return "OPENAI_API_KEY is not set."
     model = _resolve_model(ENV_OPENAI_MODEL, OPENAI_MODEL)
     return AnyLLMJudge(model, "openai", api_key=api_key)
 
@@ -169,27 +173,37 @@ def _default_judge_llm() -> JudgeLLM:
     backend = os.environ.get(ENV_BACKEND, "").lower()
 
     if backend == "openai":
-        if (judge := _discover_openai()) is not None:
-            return judge
-        pytest.fail("PYTEST_LLM_RUBRIC_BACKEND=openai but OPENAI_API_KEY is not set.")
+        result = _discover_openai()
+        if isinstance(result, AnyLLMJudge):
+            return result
+        pytest.fail(f"PYTEST_LLM_RUBRIC_BACKEND=openai but {result}")
 
     elif backend == "anthropic":
-        if (judge := _discover_anthropic()) is not None:
-            return judge
-        pytest.fail("PYTEST_LLM_RUBRIC_BACKEND=anthropic but ANTHROPIC_API_KEY is not set.")
+        result = _discover_anthropic()
+        if isinstance(result, AnyLLMJudge):
+            return result
+        pytest.fail(f"PYTEST_LLM_RUBRIC_BACKEND=anthropic but {result}")
 
     elif backend == "ollama" or backend == "":
-        if (judge := _discover_ollama()) is not None:
-            return judge
+        result = _discover_ollama()
+        if isinstance(result, AnyLLMJudge):
+            return result
         if backend == "ollama":
-            pytest.fail("PYTEST_LLM_RUBRIC_BACKEND=ollama but Ollama is not running.")
-        pytest.skip("No LLM backend available. Run Ollama or set PYTEST_LLM_RUBRIC_BACKEND.")
+            pytest.fail(f"PYTEST_LLM_RUBRIC_BACKEND=ollama but {result}")
+        pytest.skip(result)
 
     elif backend == "auto":
-        for discover in (_discover_ollama, _discover_anthropic, _discover_openai):
-            if (judge := discover()) is not None:
-                return judge
-        pytest.fail("PYTEST_LLM_RUBRIC_BACKEND=auto but no backend found.")
+        reasons: list[str] = []
+        for name, discover in [
+            ("ollama", _discover_ollama),
+            ("anthropic", _discover_anthropic),
+            ("openai", _discover_openai),
+        ]:
+            result = discover()
+            if isinstance(result, AnyLLMJudge):
+                return result
+            reasons.append(f"  {name}: {result}")
+        pytest.fail("PYTEST_LLM_RUBRIC_BACKEND=auto but no backend found.\n" + "\n".join(reasons))
 
     else:
         pytest.fail(f"Unknown PYTEST_LLM_RUBRIC_BACKEND: {backend!r}")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -20,8 +20,8 @@ from pytest_llm_rubric.plugin import (
 
 
 class TestDiscoverOllama:
-    def test_returns_none_when_ollama_package_missing(self, monkeypatch):
-        """Should return None with a warning when the ollama package is not importable."""
+    def test_returns_reason_when_ollama_package_missing(self, monkeypatch):
+        """Should return a reason string when the ollama package is not importable."""
         import builtins
         import importlib
 
@@ -37,33 +37,39 @@ class TestDiscoverOllama:
         if "ollama" in importlib.sys.modules:
             monkeypatch.delitem(importlib.sys.modules, "ollama")
 
-        with pytest.warns(match="ollama package is not installed"):
-            assert _discover_ollama() is None
+        result = _discover_ollama()
+        assert isinstance(result, str)
+        assert "not installed" in result
 
     def test_returns_judge_when_running(self):
-        judge = _discover_ollama()
-        if judge is None:
-            pytest.skip("Ollama is not running")
-        assert isinstance(judge, AnyLLMJudge)
+        result = _discover_ollama()
+        if isinstance(result, str):
+            pytest.skip(f"Ollama is not running: {result}")
+        assert isinstance(result, AnyLLMJudge)
 
-    def test_returns_none_when_unreachable(self, monkeypatch):
+    def test_returns_reason_when_unreachable(self, monkeypatch):
         monkeypatch.setenv("OLLAMA_HOST", "http://localhost:19999")
-        assert _discover_ollama() is None
+        result = _discover_ollama()
+        assert isinstance(result, str)
+        assert "Could not connect" in result
 
-    def test_returns_none_when_model_not_found(self, monkeypatch):
-        """Requesting a non-existent model should return None, not silently substitute."""
+    def test_returns_reason_when_model_not_found(self, monkeypatch):
+        """Requesting a non-existent model should return a reason, not silently substitute."""
         monkeypatch.setenv("PYTEST_LLM_RUBRIC_OLLAMA_MODEL", "nonexistent-model-xyz")
-        judge = _discover_ollama()
-        if judge is not None:
+        result = _discover_ollama()
+        if isinstance(result, AnyLLMJudge):
             # Ollama is not running or has the exact model — skip
             pytest.skip("Ollama not running or model unexpectedly exists")
-        assert judge is None
+        assert isinstance(result, str)
+        assert "not found" in result
 
 
 class TestDiscoverAnthropic:
-    def test_returns_none_without_key(self, monkeypatch):
+    def test_returns_reason_without_key(self, monkeypatch):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        assert _discover_anthropic() is None
+        result = _discover_anthropic()
+        assert isinstance(result, str)
+        assert "ANTHROPIC_API_KEY" in result
 
     def test_returns_judge_with_key(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
@@ -72,9 +78,11 @@ class TestDiscoverAnthropic:
 
 
 class TestDiscoverOpenAI:
-    def test_returns_none_without_key(self, monkeypatch):
+    def test_returns_reason_without_key(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        assert _discover_openai() is None
+        result = _discover_openai()
+        assert isinstance(result, str)
+        assert "OPENAI_API_KEY" in result
 
     def test_returns_judge_with_key(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
@@ -216,8 +224,9 @@ class TestJudgeLLMFixture:
             def test_uses_judge(judge_llm):
                 assert judge_llm is not None
         """)
-        result = pytester.runpytest_subprocess("-v")
+        result = pytester.runpytest_subprocess("-v", "-rs")
         result.assert_outcomes(skipped=1)
+        result.stdout.fnmatch_lines(["*Could not connect to Ollama*"])
 
     def test_default_backend_ignores_api_keys(self, pytester, monkeypatch):
         """Default (empty) backend must use Ollama only, even when paid API keys are present."""
@@ -279,6 +288,28 @@ class TestJudgeLLMFixture:
         result = pytester.runpytest_subprocess("-v")
         result.assert_outcomes(errors=1)
 
+    def test_auto_backend_fails_with_reasons(self, pytester, monkeypatch):
+        """Auto mode should list per-provider reasons when all backends fail."""
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "auto")
+        monkeypatch.setenv("OLLAMA_HOST", "http://localhost:19999")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("PYTHONUTF8", "1")
+        pytester.makeconftest("")
+        pytester.makepyfile("""
+            def test_uses_judge(judge_llm):
+                assert judge_llm is not None
+        """)
+        result = pytester.runpytest_subprocess("-v")
+        result.assert_outcomes(errors=1)
+        result.stdout.fnmatch_lines(
+            [
+                "*ollama: Could not connect*",
+                "*anthropic: ANTHROPIC_API_KEY*",
+                "*openai: OPENAI_API_KEY*",
+            ]
+        )
+
     def test_unknown_backend_fails(self, pytester, monkeypatch):
         monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "bogus")
         monkeypatch.setenv("PYTHONUTF8", "1")
@@ -323,9 +354,10 @@ class TestJudgeLLMFixture:
 @pytest.mark.integration
 class TestIntegration:
     def test_ollama_complete(self):
-        judge = _discover_ollama()
-        if judge is None:
-            pytest.skip("Ollama is not running")
+        result = _discover_ollama()
+        if isinstance(result, str):
+            pytest.skip(f"Ollama is not running: {result}")
+        judge = result
         response = judge.complete(
             [
                 {"role": "user", "content": "Reply with exactly: hello"},
@@ -336,9 +368,9 @@ class TestIntegration:
     def test_anthropic_complete(self):
         if not os.environ.get("ANTHROPIC_API_KEY"):
             pytest.skip("ANTHROPIC_API_KEY not set")
-        judge = _discover_anthropic()
-        assert judge is not None
-        response = judge.complete(
+        result = _discover_anthropic()
+        assert isinstance(result, AnyLLMJudge)
+        response = result.complete(
             [
                 {"role": "user", "content": "Reply with exactly: hello"},
             ]
@@ -348,9 +380,9 @@ class TestIntegration:
     def test_openai_complete(self):
         if not os.environ.get("OPENAI_API_KEY"):
             pytest.skip("OPENAI_API_KEY not set")
-        judge = _discover_openai()
-        assert judge is not None
-        response = judge.complete(
+        result = _discover_openai()
+        assert isinstance(result, AnyLLMJudge)
+        response = result.complete(
             [
                 {"role": "user", "content": "Reply with exactly: hello"},
             ]


### PR DESCRIPTION
## Summary
- `_discover_*()` functions now return a reason string on failure instead of `None`, making error messages visible without `-rs` or `-W` flags
- `_default_judge_llm()` includes the reason directly in `pytest.skip()` / `pytest.fail()` messages
- `auto` backend mode aggregates per-provider failure reasons

Closes #21

## Test plan
- [x] Unit tests pass (`uv run pytest -m "not integration" -v`)
- [x] Integration tests pass (`uv run pytest -m integration -v`)
- [x] Lint clean (`uv run ruff check src/ tests/`)
- [x] Type check clean (`uv run ty check src/`)
- [x] New test `test_auto_backend_fails_with_reasons` verifies aggregated error output
- [x] `test_skip_when_no_backend` now verifies skip message contains specific reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)