### PR TITLE
fix: mock httpx in model-not-found test to avoid CI failure

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -56,10 +56,10 @@ class TestDiscoverOllama:
     def test_returns_reason_when_model_not_found(self, monkeypatch):
         """Requesting a non-existent model should return a reason, not silently substitute."""
         monkeypatch.setenv("PYTEST_LLM_RUBRIC_OLLAMA_MODEL", "nonexistent-model-xyz")
-        result = _discover_ollama()
-        if isinstance(result, AnyLLMJudge):
-            # Ollama is not running or has the exact model — skip
-            pytest.skip("Ollama not running or model unexpectedly exists")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"models": [{"name": "some-real-model:latest"}]}
+        with patch("httpx.get", return_value=mock_resp):
+            result = _discover_ollama()
         assert isinstance(result, str)
         assert "not found" in result
 


### PR DESCRIPTION
## Summary
- `test_returns_reason_when_model_not_found` was failing in CI because Ollama is not running — `_discover_ollama()` returned "Could not connect" instead of "not found"
- The previous fix used conditional `pytest.skip`, but the skip condition didn't cover the no-Ollama case, and string matching on error messages is fragile
- Replaced with `httpx.get` mock to simulate a reachable Ollama that lacks the requested model, making the test deterministic regardless of environment

## Test plan
- [x] `pytest -m "not integration"` — 82 passed (was 1 failed before fix)
- [x] `pytest -m integration` — 3 passed
- [x] Verified with `OLLAMA_HOST=http://localhost:19999` (simulated unreachable) — test passes via mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)
