### PR TITLE
feat: simplify env vars and add any-llm provider passthrough

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,18 +31,17 @@ This is a pytest plugin (`pytest11` entry point) that provides `judge_llm`, a se
 
 - **`find_local_model.py`** — CLI tool that runs preflight against all local models (currently Ollama) and recommends the smallest passing one.
 
-**Backend discovery order** is controlled by `PYTEST_LLM_RUBRIC_BACKEND`:
+**Provider selection** is controlled by `PYTEST_LLM_RUBRIC_PROVIDER`:
 - Empty (default): Ollama only — safe, no API costs
 - `auto`: Ollama → Anthropic → OpenAI
-- Explicit: `ollama` / `anthropic` / `openai`
+- Curated: `ollama` / `anthropic` / `openai` — built-in discovery with API key checks and model validation
+- Any other value (e.g. `mistral`, `groq`): passed through to any-llm, which handles API keys and base URLs
 
-Anthropic is accessed via its OpenAI-compatible endpoint (`api.anthropic.com/v1`), so all three providers use `OpenAICompatibleJudge`.
-
-**Model resolution** for each provider: `PYTEST_LLM_RUBRIC_<PROVIDER>_MODEL` > `PYTEST_LLM_RUBRIC_MODEL` > default in `defaults.py`. This prevents model name collisions when `auto` mode falls through multiple providers.
+**Model resolution**: `PYTEST_LLM_RUBRIC_MODEL` > default in `defaults.py` (for curated providers). Passthrough providers require `PYTEST_LLM_RUBRIC_MODEL` to be set.
 
 ## Key Design Decisions
 
 - The `judge_llm` fixture is `scope="session"` — preflight runs once per test session.
-- `PYTEST_LLM_RUBRIC_BACKEND` defaults to empty (Ollama only) to prevent accidental API costs. Cloud APIs require explicit opt-in.
+- `PYTEST_LLM_RUBRIC_PROVIDER` defaults to empty (Ollama only) to prevent accidental API costs. Cloud APIs require explicit opt-in.
 - `max_tokens=512` for preflight calls (accommodates thinking models), `256` default for general use.
 - Preflight golden tests include "haystack" pairs (rule buried in long doc vs. similar doc without the rule) to screen out models that can only do trivial matching.

--- a/README.md
+++ b/README.md
@@ -92,33 +92,34 @@ def test_policy_expresses_rule(judge_llm: JudgeLLM, doc, rule):
 
 All configuration is through environment variables.
 
-### Backend selection
+### Provider selection
 
-Cloud backends require their corresponding extra:
-
-| `PYTEST_LLM_RUBRIC_BACKEND` | Extra | API key |
+| `PYTEST_LLM_RUBRIC_PROVIDER` | Extra | API key |
 |---|---|---|
 | (empty) / `ollama` | — (included) | — |
 | `anthropic` | `[anthropic]` | `ANTHROPIC_API_KEY` |
 | `openai` | `[openai]` | `OPENAI_API_KEY` |
 | `auto` | any of the above | — |
+| `<other>` (e.g. `mistral`, `groq`) | install provider SDK | provider's own env var |
 
 `auto` tries Ollama → Anthropic → OpenAI, using the first available.
-If the default (empty) backend is unavailable or preflight fails, dependent tests are skipped. If an explicit backend (`ollama`, `anthropic`, `openai`, `auto`) is set but unavailable, tests **fail** to surface CI misconfigurations.
+If the default (empty) provider is unavailable or preflight fails, dependent tests are skipped. If an explicit provider is set but unavailable, tests **fail** to surface CI misconfigurations.
+
+Providers beyond the built-in three are passed through to [any-llm](https://github.com/jtsang4/any-llm), which handles API key and base URL resolution for 38+ providers.
 
 CI example:
 
 <!--pytest.mark.skip-->
 ```yaml
 env:
-  PYTEST_LLM_RUBRIC_BACKEND: openai  # or: anthropic
-  PYTEST_LLM_RUBRIC_OPENAI_MODEL: gpt-5.4-mini
+  PYTEST_LLM_RUBRIC_PROVIDER: openai  # or: anthropic, mistral, groq, ...
+  PYTEST_LLM_RUBRIC_MODEL: gpt-5.4-mini
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
 ### Model selection
 
-Override the default model per provider with `PYTEST_LLM_RUBRIC_<PROVIDER>_MODEL` (e.g. `PYTEST_LLM_RUBRIC_OLLAMA_MODEL=gpt-oss:20b`). Defaults are in [`defaults.py`](src/pytest_llm_rubric/defaults.py).
+Override the default model with `PYTEST_LLM_RUBRIC_MODEL`. Curated provider defaults are in [`defaults.py`](src/pytest_llm_rubric/defaults.py). Passthrough providers (`mistral`, `groq`, etc.) require `PYTEST_LLM_RUBRIC_MODEL` to be set.
 
 ### Skipping preflight
 

--- a/experiments/test_qwen_thinking.py
+++ b/experiments/test_qwen_thinking.py
@@ -60,14 +60,8 @@ def run_test(label: str, *, max_tokens: int, nothink: bool) -> None:
             print(f"  expected={case['expected']:<4}  ERROR: {e}")
 
 
-# Test 1: Default (thinking enabled, max_tokens=16) — current behavior
-run_test("default (thinking, 16 tokens)", max_tokens=16, nothink=False)
+# Test 1: Default (thinking enabled, max_tokens=512) — matches preflight
+run_test("default (thinking, 512 tokens)", max_tokens=512, nothink=False)
 
-# Test 2: Thinking enabled but more tokens
-run_test("thinking + 256 tokens", max_tokens=256, nothink=False)
-
-# Test 3: Nothink + 16 tokens
-run_test("nothink + 16 tokens", max_tokens=16, nothink=True)
-
-# Test 4: Nothink + 256 tokens
-run_test("nothink + 256 tokens", max_tokens=256, nothink=True)
+# Test 2: Nothink + 512 tokens
+run_test("nothink + 512 tokens", max_tokens=512, nothink=True)

--- a/src/pytest_llm_rubric/plugin.py
+++ b/src/pytest_llm_rubric/plugin.py
@@ -16,18 +16,14 @@ from pytest_llm_rubric.defaults import (
 from pytest_llm_rubric.preflight import preflight
 from pytest_llm_rubric.utils import parse_ollama_host
 
-ENV_BACKEND = "PYTEST_LLM_RUBRIC_BACKEND"
+ENV_PROVIDER = "PYTEST_LLM_RUBRIC_PROVIDER"
 ENV_MODEL = "PYTEST_LLM_RUBRIC_MODEL"
 ENV_SKIP_PREFLIGHT = "PYTEST_LLM_RUBRIC_SKIP_PREFLIGHT"
-ENV_OLLAMA_MODEL = "PYTEST_LLM_RUBRIC_OLLAMA_MODEL"
-ENV_ANTHROPIC_MODEL = "PYTEST_LLM_RUBRIC_ANTHROPIC_MODEL"
-ENV_ANTHROPIC_BASE_URL = "PYTEST_LLM_RUBRIC_ANTHROPIC_BASE_URL"
-ENV_OPENAI_MODEL = "PYTEST_LLM_RUBRIC_OPENAI_MODEL"
 
 
-def _resolve_model(env_var: str, default: str) -> str:
-    """Resolve model name: provider-specific env var > shared env var > default."""
-    return os.environ.get(env_var) or os.environ.get(ENV_MODEL) or default
+def _resolve_model(default: str) -> str:
+    """Resolve model name: PYTEST_LLM_RUBRIC_MODEL env var > default."""
+    return os.environ.get(ENV_MODEL) or default
 
 
 class JudgeLLM(Protocol):
@@ -117,7 +113,7 @@ def _discover_ollama() -> AnyLLMJudge | str:
         if not models:
             return "Ollama is running but has no models installed."
         available = {m["name"] for m in models}
-        requested = _resolve_model(ENV_OLLAMA_MODEL, OLLAMA_MODEL or "")
+        requested = _resolve_model(OLLAMA_MODEL or "")
         if requested and requested in available:
             model_name = requested
         elif requested and requested not in available:
@@ -140,9 +136,8 @@ def _discover_anthropic() -> AnyLLMJudge | str:
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
         return "ANTHROPIC_API_KEY is not set."
-    model = _resolve_model(ENV_ANTHROPIC_MODEL, ANTHROPIC_MODEL)
-    api_base = os.environ.get(ENV_ANTHROPIC_BASE_URL)
-    return AnyLLMJudge(model, "anthropic", api_key=api_key, api_base=api_base)
+    model = _resolve_model(ANTHROPIC_MODEL)
+    return AnyLLMJudge(model, "anthropic", api_key=api_key)
 
 
 def _discover_openai() -> AnyLLMJudge | str:
@@ -153,46 +148,47 @@ def _discover_openai() -> AnyLLMJudge | str:
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         return "OPENAI_API_KEY is not set."
-    model = _resolve_model(ENV_OPENAI_MODEL, OPENAI_MODEL)
+    model = _resolve_model(OPENAI_MODEL)
     return AnyLLMJudge(model, "openai", api_key=api_key)
 
 
 def _default_judge_llm() -> JudgeLLM:
     """Auto-discover an available LLM backend.
 
-    Controlled by PYTEST_LLM_RUBRIC_BACKEND:
+    Controlled by PYTEST_LLM_RUBRIC_PROVIDER:
       (unset)    - try Ollama only, skip if unavailable
       auto       - try Ollama → Anthropic → OpenAI; fail if none found
       ollama     - Ollama only; fail if unavailable
       anthropic  - Anthropic API only; fail if unavailable
       openai     - OpenAI API only; fail if unavailable
+      <other>    - pass provider + model to AnyLLMJudge (any-llm handles it)
 
-    Explicit backends fail (pytest.fail) instead of skip so that CI
+    Explicit providers fail (pytest.fail) instead of skip so that CI
     misconfigurations surface as errors rather than silent skips.
     """
-    backend = os.environ.get(ENV_BACKEND, "").lower()
+    provider = os.environ.get(ENV_PROVIDER, "").lower()
 
-    if backend == "openai":
+    if provider == "openai":
         result = _discover_openai()
         if isinstance(result, AnyLLMJudge):
             return result
-        pytest.fail(f"PYTEST_LLM_RUBRIC_BACKEND=openai but {result}")
+        pytest.fail(f"PYTEST_LLM_RUBRIC_PROVIDER=openai but {result}")
 
-    elif backend == "anthropic":
+    elif provider == "anthropic":
         result = _discover_anthropic()
         if isinstance(result, AnyLLMJudge):
             return result
-        pytest.fail(f"PYTEST_LLM_RUBRIC_BACKEND=anthropic but {result}")
+        pytest.fail(f"PYTEST_LLM_RUBRIC_PROVIDER=anthropic but {result}")
 
-    elif backend == "ollama" or backend == "":
+    elif provider == "ollama" or provider == "":
         result = _discover_ollama()
         if isinstance(result, AnyLLMJudge):
             return result
-        if backend == "ollama":
-            pytest.fail(f"PYTEST_LLM_RUBRIC_BACKEND=ollama but {result}")
+        if provider == "ollama":
+            pytest.fail(f"PYTEST_LLM_RUBRIC_PROVIDER=ollama but {result}")
         pytest.skip(result)
 
-    elif backend == "auto":
+    elif provider == "auto":
         reasons: list[str] = []
         for name, discover in [
             ("ollama", _discover_ollama),
@@ -203,10 +199,16 @@ def _default_judge_llm() -> JudgeLLM:
             if isinstance(result, AnyLLMJudge):
                 return result
             reasons.append(f"  {name}: {result}")
-        pytest.fail("PYTEST_LLM_RUBRIC_BACKEND=auto but no backend found.\n" + "\n".join(reasons))
+        pytest.fail("PYTEST_LLM_RUBRIC_PROVIDER=auto but no backend found.\n" + "\n".join(reasons))
 
     else:
-        pytest.fail(f"Unknown PYTEST_LLM_RUBRIC_BACKEND: {backend!r}")
+        model = os.environ.get(ENV_MODEL)
+        if not model:
+            pytest.fail(
+                f"PYTEST_LLM_RUBRIC_PROVIDER={provider!r} requires "
+                f"PYTEST_LLM_RUBRIC_MODEL to be set."
+            )
+        return AnyLLMJudge(model, provider)
 
 
 def _preflight_or_skip(judge: JudgeLLM) -> JudgeLLM:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -55,7 +55,7 @@ class TestDiscoverOllama:
 
     def test_returns_reason_when_model_not_found(self, monkeypatch):
         """Requesting a non-existent model should return a reason, not silently substitute."""
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_OLLAMA_MODEL", "nonexistent-model-xyz")
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "nonexistent-model-xyz")
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"models": [{"name": "some-real-model:latest"}]}
         with patch("httpx.get", return_value=mock_resp):
@@ -217,7 +217,7 @@ def judge_llm():
 
 class TestJudgeLLMFixture:
     def test_skip_when_no_backend(self, pytester, monkeypatch):
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "")
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "")
         monkeypatch.setenv("OLLAMA_HOST", "http://localhost:19999")
         pytester.makeconftest("")
         pytester.makepyfile("""
@@ -230,7 +230,7 @@ class TestJudgeLLMFixture:
 
     def test_default_backend_ignores_api_keys(self, pytester, monkeypatch):
         """Default (empty) backend must use Ollama only, even when paid API keys are present."""
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "")
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "")
         monkeypatch.setenv("OLLAMA_HOST", "http://localhost:19999")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-should-not-be-used")
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test-should-not-be-used")
@@ -253,7 +253,7 @@ class TestJudgeLLMFixture:
         result.assert_outcomes(passed=1)
 
     def test_explicit_ollama_fails_when_unavailable(self, pytester, monkeypatch):
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "ollama")
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "ollama")
         monkeypatch.setenv("OLLAMA_HOST", "http://localhost:19999")
         monkeypatch.setenv("PYTHONUTF8", "1")
         pytester.makeconftest("")
@@ -265,7 +265,7 @@ class TestJudgeLLMFixture:
         result.assert_outcomes(errors=1)
 
     def test_explicit_openai_fails_without_key(self, pytester, monkeypatch):
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "openai")
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "openai")
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.setenv("PYTHONUTF8", "1")
         pytester.makeconftest("")
@@ -277,7 +277,7 @@ class TestJudgeLLMFixture:
         result.assert_outcomes(errors=1)
 
     def test_explicit_anthropic_fails_without_key(self, pytester, monkeypatch):
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "anthropic")
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "anthropic")
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("PYTHONUTF8", "1")
         pytester.makeconftest("")
@@ -290,7 +290,7 @@ class TestJudgeLLMFixture:
 
     def test_auto_backend_fails_with_reasons(self, pytester, monkeypatch):
         """Auto mode should list per-provider reasons when all backends fail."""
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "auto")
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "auto")
         monkeypatch.setenv("OLLAMA_HOST", "http://localhost:19999")
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -310,8 +310,10 @@ class TestJudgeLLMFixture:
             ]
         )
 
-    def test_unknown_backend_fails(self, pytester, monkeypatch):
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_BACKEND", "bogus")
+    def test_passthrough_provider_requires_model(self, pytester, monkeypatch):
+        """Passthrough providers must have PYTEST_LLM_RUBRIC_MODEL set."""
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "groq")
+        monkeypatch.delenv("PYTEST_LLM_RUBRIC_MODEL", raising=False)
         monkeypatch.setenv("PYTHONUTF8", "1")
         pytester.makeconftest("")
         pytester.makepyfile("""
@@ -320,6 +322,25 @@ class TestJudgeLLMFixture:
         """)
         result = pytester.runpytest_subprocess("-v")
         result.assert_outcomes(errors=1)
+        result.stdout.fnmatch_lines(["*requires*PYTEST_LLM_RUBRIC_MODEL*"])
+
+    def test_passthrough_provider_creates_judge(self, pytester, monkeypatch):
+        """Passthrough provider + model creates AnyLLMJudge without calling the LLM.
+
+        Groq SDK is not installed, but discovery only constructs the object.
+        SKIP_PREFLIGHT=1 avoids an actual completion() call.
+        """
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "groq")
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "llama-3.3-70b-versatile")
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_SKIP_PREFLIGHT", "1")
+        monkeypatch.setenv("PYTHONUTF8", "1")
+        pytester.makeconftest("")
+        pytester.makepyfile("""
+            def test_uses_judge(judge_llm):
+                assert judge_llm is not None
+        """)
+        result = pytester.runpytest_subprocess("-v")
+        result.assert_outcomes(passed=1)
 
     def test_llm_rubric_marker_auto_applied(self, pytester):
         pytester.makeconftest(_FAKE_JUDGE_CONFTEST)


### PR DESCRIPTION
Closes #19

## Summary
- Rename `PYTEST_LLM_RUBRIC_BACKEND` → `PYTEST_LLM_RUBRIC_PROVIDER` (semantic clarity)
- Remove 4 per-provider env vars: `*_OLLAMA_MODEL`, `*_ANTHROPIC_MODEL`, `*_OPENAI_MODEL`, `*_ANTHROPIC_BASE_URL`
- Open the `else` branch in `_default_judge_llm()` as a passthrough to any-llm — unknown provider values (e.g. `mistral`, `groq`) are forwarded directly, enabling 38+ providers with zero new discovery code
- Simplify `_resolve_model()` from 3-tier to 2-tier resolution (`PYTEST_LLM_RUBRIC_MODEL` > defaults.py)
- Fix `experiments/test_qwen_thinking.py` max_tokens to match preflight (512)

**Env vars: 7 → 3** (`PROVIDER`, `MODEL`, `SKIP_PREFLIGHT`)

## Breaking changes
- `PYTEST_LLM_RUBRIC_BACKEND` → `PYTEST_LLM_RUBRIC_PROVIDER`
- `PYTEST_LLM_RUBRIC_<PROVIDER>_MODEL` removed (use `PYTEST_LLM_RUBRIC_MODEL`)
- `PYTEST_LLM_RUBRIC_ANTHROPIC_BASE_URL` removed (use `ANTHROPIC_BASE_URL` read by any-llm natively)

## Test plan
- [x] `pytest -m "not integration"` — 83 passed
- [x] `pytest -m integration` — 3 passed (ollama, anthropic, openai)
- [x] `experiments/stability_test.py` — 12/12
- [x] `experiments/structured_output_test.py` — 12/12 (both modes)
- [x] `experiments/test_qwen_raw.py` — all PASS
- [x] `experiments/test_qwen_thinking.py` — PASS/FAIL correct with 512 tokens
- [x] Grep confirms zero references to old env var names
- [x] Pre-commit hooks pass (ruff check, ruff format, ty check, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
