### PR TITLE
feat: add judge() convenience method and export parse_verdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,7 @@ def test_mentions_deadline(judge_llm):
     # In practice, text is usually much longer —
     # policy docs, generated reports, LLM outputs, etc.
     text = "The report is due by March 31st."
-    criterion = "The delivery deadline is mentioned."
-    response = judge_llm.complete([
-        {"role": "system", "content": "Does this text express the criterion? Reply PASS or FAIL."},
-        {"role": "user", "content": f"TEXT:\n{text}\n\nCRITERION:\n{criterion}"},
-    ])
-    assert "PASS" in response.upper()
+    assert judge_llm.judge(text, "The delivery deadline is mentioned.")
 ```
 
 ## Execution Flow
@@ -80,12 +75,7 @@ REQUIRED_RULES = [
 @pytest.mark.parametrize("doc", POLICY_DOCS)
 @pytest.mark.parametrize("rule", REQUIRED_RULES)
 def test_policy_expresses_rule(judge_llm: JudgeLLM, doc, rule):
-    text = doc.read_text()
-    response = judge_llm.complete([
-        {"role": "system", "content": "Does this document express the criterion? Reply PASS or FAIL."},
-        {"role": "user", "content": f"DOCUMENT:\n{text}\n\nCRITERION:\n{rule}"},
-    ])
-    assert "PASS" in response.upper(), f"{doc} is missing rule: {rule}"
+    assert judge_llm.judge(doc.read_text(), rule), f"{doc} is missing rule: {rule}"
 ```
 
 ## Configuration
@@ -157,8 +147,10 @@ Override the `judge_llm` fixture for a custom LLM client or internal gateway.
 
 ```python
 import pytest
+import requests
+from pytest_llm_rubric import AnyLLMJudge
 
-class MyBackend:
+class MyBackend(AnyLLMJudge):
     def complete(self, messages, max_output_tokens=256, response_format=None):
         # Call your internal LLM gateway
         resp = requests.post("https://internal-llm.corp/v1/chat", json={"messages": messages})
@@ -166,7 +158,25 @@ class MyBackend:
 
 @pytest.fixture(scope="session")
 def judge_llm():
-    return MyBackend()
+    return MyBackend("my-model", "custom")
+```
+
+Extending `AnyLLMJudge` gives you the `judge()` convenience method for free. If you prefer a standalone class, implement both `complete()` and `judge()` (see the `JudgeLLM` protocol).
+
+### Low-level API
+
+The `judge()` method covers most use cases. For full control over messages, use `complete()` directly:
+
+```python
+from pytest_llm_rubric import parse_verdict
+
+def test_custom_prompt(judge_llm):
+    response = judge_llm.complete([
+        {"role": "system", "content": "Your custom system prompt. Reply PASS or FAIL."},
+        {"role": "user", "content": f"DOCUMENT:\n{text}\n\nCRITERION:\n{criterion}"},
+    ])
+    verdict = parse_verdict(response)
+    assert verdict == "PASS"
 ```
 
 ### Custom system prompt

--- a/src/pytest_llm_rubric/__init__.py
+++ b/src/pytest_llm_rubric/__init__.py
@@ -6,13 +6,21 @@
 
 
 def __getattr__(name: str):  # noqa: ANN001
-    if name in ("PreflightResult", "Verdict", "preflight"):
-        from pytest_llm_rubric.preflight import PreflightResult, Verdict, preflight
+    if name in ("PreflightResult", "Verdict", "preflight", "parse_verdict", "JUDGE_SYSTEM_PROMPT"):
+        from pytest_llm_rubric.preflight import (
+            JUDGE_SYSTEM_PROMPT,
+            PreflightResult,
+            Verdict,
+            parse_verdict,
+            preflight,
+        )
 
         _exports = {
             "PreflightResult": PreflightResult,
             "Verdict": Verdict,
             "preflight": preflight,
+            "parse_verdict": parse_verdict,
+            "JUDGE_SYSTEM_PROMPT": JUDGE_SYSTEM_PROMPT,
         }
         return _exports[name]
     if name in ("JudgeLLM", "AnyLLMJudge"):
@@ -25,8 +33,10 @@ def __getattr__(name: str):  # noqa: ANN001
 
 __all__ = [
     "AnyLLMJudge",
-    "PreflightResult",
+    "JUDGE_SYSTEM_PROMPT",
     "JudgeLLM",
+    "PreflightResult",
     "Verdict",
+    "parse_verdict",
     "preflight",
 ]

--- a/src/pytest_llm_rubric/plugin.py
+++ b/src/pytest_llm_rubric/plugin.py
@@ -13,7 +13,7 @@ from pytest_llm_rubric.defaults import (
     OLLAMA_MODEL,
     OPENAI_MODEL,
 )
-from pytest_llm_rubric.preflight import preflight
+from pytest_llm_rubric.preflight import JUDGE_SYSTEM_PROMPT, parse_verdict, preflight
 from pytest_llm_rubric.utils import parse_ollama_host
 
 ENV_PROVIDER = "PYTEST_LLM_RUBRIC_PROVIDER"
@@ -35,6 +35,8 @@ class JudgeLLM(Protocol):
         max_output_tokens: int = 256,
         response_format: type | None = None,
     ) -> str: ...
+
+    def judge(self, document: str, criterion: str) -> bool: ...
 
 
 class AnyLLMJudge:
@@ -90,6 +92,25 @@ class AnyLLMJudge:
                     stacklevel=2,
                 )
         return ""
+
+    def judge(self, document: str, criterion: str) -> bool:
+        """Evaluate whether a document meets a criterion.
+
+        Returns True (PASS) or False (FAIL).
+        Raises ValueError if the LLM response cannot be parsed as a verdict.
+        """
+        messages = [
+            {"role": "system", "content": JUDGE_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": f"DOCUMENT:\n{document}\n\nCRITERION:\n{criterion}",
+            },
+        ]
+        raw = self.complete(messages).strip()
+        verdict = parse_verdict(raw)
+        if verdict.startswith("INVALID"):
+            raise ValueError(f"Could not parse verdict from LLM response: {raw!r}")
+        return verdict == "PASS"
 
 
 def _discover_ollama() -> AnyLLMJudge | str:

--- a/src/pytest_llm_rubric/preflight.py
+++ b/src/pytest_llm_rubric/preflight.py
@@ -29,7 +29,7 @@ class Verdict(BaseModel):
     result: Literal["PASS", "FAIL"]
 
 
-def _parse_verdict(raw: str) -> str:
+def parse_verdict(raw: str) -> str:
     """Extract PASS/FAIL from a response, trying JSON first then regex."""
     try:
         data = json.loads(raw)
@@ -85,7 +85,7 @@ def preflight(llm: JudgeLLM, system_prompt: str | None = None) -> PreflightResul
             raw_response = llm.complete(
                 messages, max_output_tokens=512, response_format=Verdict
             ).strip()
-            verdict = _parse_verdict(raw_response)
+            verdict = parse_verdict(raw_response)
         except Exception as e:
             verdict = f"ERROR: {e}"
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -194,6 +194,51 @@ class TestAnyLLMJudge:
         assert mock_comp.call_count == 1
 
 
+class TestJudgeMethod:
+    """Tests for AnyLLMJudge.judge() convenience method."""
+
+    def test_judge_returns_true_on_pass(self):
+        mock_response = MagicMock(choices=[MagicMock(message=MagicMock(content="PASS"))])
+        with patch("any_llm.completion", return_value=mock_response):
+            judge = AnyLLMJudge("m", "openai", api_key="k")
+            assert judge.judge("The deadline is Friday.", "mentions a deadline") is True
+
+    def test_judge_returns_false_on_fail(self):
+        mock_response = MagicMock(choices=[MagicMock(message=MagicMock(content="FAIL"))])
+        with patch("any_llm.completion", return_value=mock_response):
+            judge = AnyLLMJudge("m", "openai", api_key="k")
+            assert judge.judge("Hello world.", "mentions a deadline") is False
+
+    def test_judge_raises_on_invalid_response(self):
+        mock_response = MagicMock(choices=[MagicMock(message=MagicMock(content="JUNK"))])
+        with patch("any_llm.completion", return_value=mock_response):
+            judge = AnyLLMJudge("m", "openai", api_key="k")
+            with pytest.raises(ValueError, match="Could not parse verdict"):
+                judge.judge("doc", "criterion")
+
+    def test_judge_accepts_json_verdict(self):
+        mock_response = MagicMock(
+            choices=[MagicMock(message=MagicMock(content='{"result": "PASS"}'))]
+        )
+        with patch("any_llm.completion", return_value=mock_response):
+            judge = AnyLLMJudge("m", "openai", api_key="k")
+            assert judge.judge("doc", "criterion") is True
+
+    def test_judge_sends_system_prompt(self):
+        from pytest_llm_rubric.preflight import JUDGE_SYSTEM_PROMPT
+
+        mock_response = MagicMock(choices=[MagicMock(message=MagicMock(content="PASS"))])
+        with patch("any_llm.completion", return_value=mock_response) as mock_comp:
+            judge = AnyLLMJudge("m", "openai", api_key="k")
+            judge.judge("doc", "criterion")
+
+        messages = mock_comp.call_args.kwargs["messages"]
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == JUDGE_SYSTEM_PROMPT
+        assert "DOCUMENT:\ndoc" in messages[1]["content"]
+        assert "CRITERION:\ncriterion" in messages[1]["content"]
+
+
 # ---------------------------------------------------------------------------
 # Fixture tests (using pytester for isolation)
 # ---------------------------------------------------------------------------

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from pytest_llm_rubric.preflight import (
     GOLDEN_TESTS,
     JUDGE_SYSTEM_PROMPT,
-    _parse_verdict,
+    parse_verdict,
     preflight,
 )
 
@@ -153,22 +153,22 @@ class TestPreflight:
 
 class TestParseVerdict:
     def test_json_pass(self):
-        assert _parse_verdict('{"result": "PASS"}') == "PASS"
+        assert parse_verdict('{"result": "PASS"}') == "PASS"
 
     def test_json_fail(self):
-        assert _parse_verdict('{"result": "FAIL"}') == "FAIL"
+        assert parse_verdict('{"result": "FAIL"}') == "FAIL"
 
     def test_freetext_pass(self):
-        assert _parse_verdict("PASS") == "PASS"
+        assert parse_verdict("PASS") == "PASS"
 
     def test_freetext_fail(self):
-        assert _parse_verdict("FAIL") == "FAIL"
+        assert parse_verdict("FAIL") == "FAIL"
 
     def test_decorated_freetext(self):
-        assert _parse_verdict("**PASS**") == "PASS"
+        assert parse_verdict("**PASS**") == "PASS"
 
     def test_invalid(self):
-        assert _parse_verdict("JUNK").startswith("INVALID")
+        assert parse_verdict("JUNK").startswith("INVALID")
 
     def test_empty(self):
-        assert _parse_verdict("").startswith("INVALID")
+        assert parse_verdict("").startswith("INVALID")


### PR DESCRIPTION
## Summary
Closes #27

- Add `judge(document, criterion) -> bool` to `AnyLLMJudge` and `JudgeLLM` Protocol — reduces each rubric test to a one-liner
- Rename `_parse_verdict` → `parse_verdict` (public API) and export from `pytest_llm_rubric`
- Export `JUDGE_SYSTEM_PROMPT` from `pytest_llm_rubric`
- Update README examples to use the new API
- Add "Low-level API" section showing `complete()` + `parse_verdict` for advanced use

**Before:**
```python
def test_mentions_deadline(judge_llm):
    response = judge_llm.complete([
        {"role": "system", "content": "Does this text express the criterion? Reply PASS or FAIL."},
        {"role": "user", "content": f"TEXT:\n{text}\n\nCRITERION:\n{criterion}"},
    ])
    assert "PASS" in response.upper()
```

**After:**
```python
def test_mentions_deadline(judge_llm):
    assert judge_llm.judge(text, "The delivery deadline is mentioned.")
```

## Test plan
- [x] 88 unit tests passed
- [x] ruff check, ruff format, ty check all passed
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
