### PR TITLE
feat!: unify PROVIDER+MODEL into provider:model syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ uv sync --extra ollama                   # Install dependencies (editable mode, 
 uv run pre-commit install                # Install pre-commit hooks (ruff + ty)
 uv run pytest -m "not integration"       # Run tests (no LLM calls)
 uv run pytest -m integration             # Run integration tests (requires Ollama / API keys)
-uv run pytest tests/test_plugin.py::TestDiscoverOllama -v  # Run a single test class
+uv run pytest tests/test_plugin.py::TestMakeJudge -v  # Run a single test class
 uv run ruff check src/ tests/            # Lint
 uv run ruff check --fix src/ tests/      # Lint with auto-fix
 uv run ruff format src/ tests/           # Format
@@ -27,21 +27,20 @@ This is a pytest plugin (`pytest11` entry point) that provides `judge_llm`, a se
 
 - **`preflight.py`** — Golden test suite (12 pairs: 6 short-form + 6 haystack) that validates whether an LLM can reliably do binary PASS/FAIL semantic judgments. Session runs preflight once; if the LLM fails, all rubric tests skip.
 
-- **`defaults.py`** — Single file for default model names and endpoints per provider. Intended to be human-editable.
+- **`defaults.py`** — `AUTO_MODELS` list of `provider:model` strings tried in order when `PYTEST_LLM_RUBRIC_MODEL=auto`. Intended to be human-editable.
 
 - **`find_local_model.py`** — CLI tool that runs preflight against all local models (currently Ollama) and recommends the smallest passing one.
 
-**Provider selection** is controlled by `PYTEST_LLM_RUBRIC_PROVIDER`:
-- Empty (default): Ollama only — safe, no API costs
-- `auto`: Ollama → Anthropic → OpenAI
-- Curated: `ollama` / `anthropic` / `openai` — built-in discovery with API key checks and model validation
-- Any other value (e.g. `mistral`, `groq`): passed through to any-llm, which handles API keys and base URLs
+**Model selection** is controlled by a single env var `PYTEST_LLM_RUBRIC_MODEL`:
+- `provider:model` (e.g. `anthropic:claude-haiku-4-5`, `ollama:qwen3.5:9b`) — direct
+- `auto` — tries each entry in `defaults.AUTO_MODELS` in order
+- Unset — error (explicit configuration required)
 
-**Model resolution**: `PYTEST_LLM_RUBRIC_MODEL` > default in `defaults.py` (for curated providers). Passthrough providers require `PYTEST_LLM_RUBRIC_MODEL` to be set.
+The `provider:model` syntax follows the any-llm-sdk convention (colon separator). The prefix before the first colon must match a known provider (built-in: `ollama`, `anthropic`, `openai`; extended via any-llm's `LLMProvider` enum for `groq`, `mistral`, etc.).
 
 ## Key Design Decisions
 
 - The `judge_llm` fixture is `scope="session"` — preflight runs once per test session.
-- `PYTEST_LLM_RUBRIC_PROVIDER` defaults to empty (Ollama only) to prevent accidental API costs. Cloud APIs require explicit opt-in.
+- `PYTEST_LLM_RUBRIC_MODEL` must be explicitly set — no silent defaults to prevent accidental API costs.
 - `max_tokens=512` for preflight calls (accommodates thinking models), `256` default for general use.
 - Preflight golden tests include "haystack" pairs (rule buried in long doc vs. similar doc without the rule) to screen out models that can only do trivial matching.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Not a general essay grader or multi-dimensional scoring system.
 ```bash
 pip install pytest-llm-rubric          # or: uv add --dev pytest-llm-rubric
 ollama serve                           # start Ollama (if not already running)
-ollama pull gpt-oss:20b               # default model (or set PYTEST_LLM_RUBRIC_MODEL)
+ollama pull gpt-oss:20b               # or any model you want to use
+export PYTEST_LLM_RUBRIC_MODEL="ollama:gpt-oss:20b"
 ```
 
 ### Minimal Test
@@ -49,11 +50,9 @@ def test_mentions_deadline(judge_llm):
 
 ## Execution Flow
 
-1. **Discover** — auto-detect available backends based on installed extras and env vars
-2. **Preflight** — verify the discovered backend can reliably judge PASS/FAIL before exposing it as `judge_llm` (skippable)
-3. **Provide, skip, or fail** — expose the `judge_llm` session fixture on success. If the default (empty) backend is unavailable or preflight fails, dependent tests are skipped. If an explicit backend is unavailable, tests fail
-
-Paid cloud APIs never run unless explicitly configured.
+1. **Discover** — resolve the backend from `PYTEST_LLM_RUBRIC_MODEL`
+2. **Preflight** — verify the backend can reliably judge PASS/FAIL before exposing it as `judge_llm` (skippable)
+3. **Provide, skip, or fail** — expose the `judge_llm` session fixture on success. If the backend is unavailable, tests **fail**. If preflight fails, tests are **skipped**
 
 ## Example: Policy Document Checks
 
@@ -80,37 +79,59 @@ def test_policy_expresses_rule(judge_llm: JudgeLLM, doc, rule):
 
 ## Configuration
 
-All configuration is through environment variables.
+### Model selection
 
-### Provider selection
+Set `PYTEST_LLM_RUBRIC_MODEL` to a `provider:model` string:
 
-| `PYTEST_LLM_RUBRIC_PROVIDER` | Extra | API key | If unavailable |
-|---|---|---|---|
-| (empty) | — (included) | — | tests **skip** |
-| `ollama` | — (included) | — | tests **fail** |
-| `anthropic` | `[anthropic]` | `ANTHROPIC_API_KEY` | tests **fail** |
-| `openai` | `[openai]` | `OPENAI_API_KEY` | tests **fail** |
-| `auto` | any of the above | — | tests **fail** |
-| `<other>` (e.g. `mistral`, `groq`) | install provider SDK | provider's own env var | tests **fail** |
+| `PYTEST_LLM_RUBRIC_MODEL` | Example | Notes |
+|---|---|---|
+| `ollama:<model>` | `ollama:gpt-oss:20b` | Local Ollama instance |
+| `anthropic:<model>` | `anthropic:claude-haiku-4-5` | Requires `ANTHROPIC_API_KEY` |
+| `openai:<model>` | `openai:gpt-5.4-nano` | Requires `OPENAI_API_KEY` |
+| `<provider>:<model>` | `groq:llama-3.3-70b` | Requires any-llm extra + provider SDK |
+| `auto` | — | Try each model in the auto-discovery list |
+| (unset) | — | Error — explicit configuration required |
 
-`auto` tries Ollama → Anthropic → OpenAI, using the first available.
-If the default (empty) provider is unavailable or preflight fails, dependent tests are skipped. If an explicit provider is set but unavailable, tests **fail** to surface CI misconfigurations.
-
-Providers beyond the built-in three are passed through to [any-llm](https://github.com/jtsang4/any-llm), which handles API key and base URL resolution for 38+ providers.
+The `provider:model` syntax follows the [any-llm-sdk](https://github.com/mozilla-ai/any-llm) convention (colon separator). Built-in providers are `ollama`, `anthropic`, and `openai`. Additional providers (e.g. `groq`, `mistral`) are recognised when any-llm is installed.
 
 CI example:
 
 <!--pytest.mark.skip-->
 ```yaml
 env:
-  PYTEST_LLM_RUBRIC_PROVIDER: openai  # or: anthropic, mistral, groq, ...
-  PYTEST_LLM_RUBRIC_MODEL: gpt-5.4-nano
-  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  PYTEST_LLM_RUBRIC_MODEL: anthropic:claude-haiku-4-5
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
-### Model selection
+### Auto-discovery
 
-Override the default model with `PYTEST_LLM_RUBRIC_MODEL`. Curated provider defaults are in [`defaults.py`](src/pytest_llm_rubric/defaults.py). Passthrough providers (`mistral`, `groq`, etc.) require `PYTEST_LLM_RUBRIC_MODEL` to be set.
+When `PYTEST_LLM_RUBRIC_MODEL=auto`, the plugin tries each model in a configurable list until one is reachable. The list is resolved in priority order:
+
+1. **Env var** `PYTEST_LLM_RUBRIC_AUTO_MODELS` — comma-separated `provider:model` strings
+2. **pytest ini option** `llm_rubric_auto_models` — in `pyproject.toml` or `pytest.ini`
+3. **Package default** — [`defaults.py`](src/pytest_llm_rubric/defaults.py)
+
+> **Note:** The default list includes cloud providers (Anthropic, OpenAI) as fallbacks after Ollama. If their API keys are set, `auto` may incur API costs. To avoid this, set `PYTEST_LLM_RUBRIC_AUTO_MODELS` to only include providers you intend to use.
+
+<!--pytest.mark.skip-->
+```toml
+# pyproject.toml — linelist format (one entry per line)
+[tool.pytest.ini_options]
+llm_rubric_auto_models = [
+    "ollama:qwen3.5:9b",
+    "anthropic:claude-haiku-4-5",
+]
+```
+
+Or equivalently in `pytest.ini`:
+
+<!--pytest.mark.skip-->
+```ini
+[pytest]
+llm_rubric_auto_models =
+    ollama:qwen3.5:9b
+    anthropic:claude-haiku-4-5
+```
 
 > **Pro tip:** Models with verbose reasoning traces (e.g. `qwen3.5` in thinking mode) can be much slower on PASS/FAIL tasks. `gpt-oss` is a good default — fast despite using medium-level reasoning.
 
@@ -160,12 +181,13 @@ class MyBackend(AnyLLMJudge):
         resp = requests.post("https://internal-llm.corp/v1/chat", json={"messages": messages})
         return resp.json()["content"]
 
+# Override the fixture directly — no provider:model env var needed.
 @pytest.fixture(scope="session")
 def judge_llm():
-    return MyBackend("my-model", "custom")
+    return MyBackend("my-model", "internal")
 ```
 
-Extending `AnyLLMJudge` gives you the `judge()` convenience method for free. If you prefer a standalone class, implement both `complete()` and `judge()` (see the `JudgeLLM` protocol).
+Extending `AnyLLMJudge` gives you the `judge()` convenience method for free. When you override the `judge_llm` fixture directly, `PYTEST_LLM_RUBRIC_MODEL` is not used. If you prefer a standalone class, implement both `complete()` and `judge()` (see the `JudgeLLM` protocol).
 
 ### Message-level API
 

--- a/src/pytest_llm_rubric/defaults.py
+++ b/src/pytest_llm_rubric/defaults.py
@@ -1,11 +1,14 @@
-"""Default models for each built-in provider.
+"""Default model list for ``auto`` discovery.
 
-These are used when PYTEST_LLM_RUBRIC_MODEL is not set.
-Override via the environment variable rather than editing this file.
+Each entry is a ``provider:model`` string tried in order.
+The first backend that is reachable wins.
+
+To customise, set ``PYTEST_LLM_RUBRIC_AUTO_MODELS`` (env var) or
+``llm_rubric_auto_models`` (pyproject.toml) instead of editing this file.
 """
 
-# Chosen for speed and stability (MoE, 20/20 preflight stable).
-# Alternative: qwen3.5:9b (smaller VRAM footprint, also stable).
-OLLAMA_MODEL = "gpt-oss:20b"
-ANTHROPIC_MODEL = "claude-haiku-4-5"
-OPENAI_MODEL = "gpt-5.4-nano"
+AUTO_MODELS: list[str] = [
+    "ollama:gpt-oss:20b",
+    "anthropic:claude-haiku-4-5",
+    "openai:gpt-5.4-nano",
+]

--- a/src/pytest_llm_rubric/find_local_model.py
+++ b/src/pytest_llm_rubric/find_local_model.py
@@ -13,17 +13,14 @@ import argparse
 import os
 import sys
 
-import httpx
-
 from pytest_llm_rubric.plugin import AnyLLMJudge
 from pytest_llm_rubric.preflight import preflight
-from pytest_llm_rubric.utils import OLLAMA_DEFAULT_HOST, OLLAMA_DEFAULT_PORT, parse_ollama_host
-
-
-def _get_ollama_models(base_url: str) -> list[dict]:
-    resp = httpx.get(f"{base_url}/api/tags", timeout=5)
-    resp.raise_for_status()
-    return resp.json().get("models", [])
+from pytest_llm_rubric.utils import (
+    OLLAMA_DEFAULT_HOST,
+    OLLAMA_DEFAULT_PORT,
+    get_ollama_models,
+    parse_ollama_host,
+)
 
 
 def _size_label(size_bytes: int) -> str:
@@ -43,7 +40,7 @@ def find_best_local_model(
     if base_url is None:
         base_url = parse_ollama_host(os.environ.get("OLLAMA_HOST"))
     try:
-        all_models = _get_ollama_models(base_url)
+        all_models = get_ollama_models(base_url)
     except Exception as e:
         print(f"Could not connect to Ollama at {base_url}: {e}")
         sys.exit(1)
@@ -109,8 +106,8 @@ def find_best_local_model(
     print()
     if recommended:
         print(f"Recommended: {recommended} (smallest passing model)")
-        print("\nSet in defaults.py or environment:")
-        print(f"  PYTEST_LLM_RUBRIC_MODEL={recommended}")
+        print("\nSet in your environment:")
+        print(f"  PYTEST_LLM_RUBRIC_MODEL=ollama:{recommended}")
     else:
         print("No model passed preflight.")
         print("Consider pulling a larger model: ollama pull granite4:3b")

--- a/src/pytest_llm_rubric/plugin.py
+++ b/src/pytest_llm_rubric/plugin.py
@@ -2,28 +2,61 @@
 
 from __future__ import annotations
 
+import functools
 import os
 import warnings
 from typing import Any, Protocol, cast
 
 import pytest
 
-from pytest_llm_rubric.defaults import (
-    ANTHROPIC_MODEL,
-    OLLAMA_MODEL,
-    OPENAI_MODEL,
-)
+from pytest_llm_rubric.defaults import AUTO_MODELS
 from pytest_llm_rubric.preflight import JUDGE_SYSTEM_PROMPT, parse_verdict, preflight
-from pytest_llm_rubric.utils import parse_ollama_host
+from pytest_llm_rubric.utils import get_ollama_models, parse_ollama_host
 
-ENV_PROVIDER = "PYTEST_LLM_RUBRIC_PROVIDER"
 ENV_MODEL = "PYTEST_LLM_RUBRIC_MODEL"
+ENV_AUTO_MODELS = "PYTEST_LLM_RUBRIC_AUTO_MODELS"
 ENV_SKIP_PREFLIGHT = "PYTEST_LLM_RUBRIC_SKIP_PREFLIGHT"
 
 
-def _resolve_model(default: str) -> str:
-    """Resolve model name: PYTEST_LLM_RUBRIC_MODEL env var > default."""
-    return os.environ.get(ENV_MODEL) or default
+@functools.cache
+def _get_known_providers() -> frozenset[str]:
+    """Return the set of recognised provider names (cached after first call)."""
+    providers: set[str] = {"ollama", "anthropic", "openai"}
+    try:
+        from any_llm import LLMProvider
+
+        providers |= {p.value.lower() for p in LLMProvider}
+    except Exception:  # pragma: no cover
+        pass
+    return frozenset(providers)
+
+
+def _parse_model(value: str) -> tuple[str, str]:
+    """Parse a ``provider:model`` string into ``(provider, model)``.
+
+    The first colon is used as the separator only when the prefix matches a
+    known provider name.  This avoids mis-parsing bare Ollama tags like
+    ``qwen3.5:9b`` (where ``qwen3.5`` is not a provider).
+
+    Raises ``ValueError`` when the provider cannot be determined.
+    """
+    if ":" not in value:
+        raise ValueError(
+            f"Invalid model format {value!r}. "
+            "Expected 'provider:model' (e.g. 'anthropic:claude-haiku-4-5')."
+        )
+
+    prefix, rest = value.split(":", 1)
+    prefix_lower = prefix.lower()
+
+    known = _get_known_providers()
+    if prefix_lower in known:
+        return prefix_lower, rest
+
+    raise ValueError(
+        f"Unknown provider {prefix!r} in model string {value!r}. "
+        f"Known providers: {', '.join(sorted(known))}."
+    )
 
 
 class JudgeLLM(Protocol):
@@ -113,123 +146,107 @@ class AnyLLMJudge:
         return verdict == "PASS"
 
 
-def _discover_ollama() -> AnyLLMJudge | str:
-    """Try to connect to a local Ollama instance.
+def _make_judge(provider: str, model: str) -> AnyLLMJudge | str:
+    """Try to construct an ``AnyLLMJudge`` for the given provider and model.
 
-    Returns an ``AnyLLMJudge`` on success, or a human-readable reason string
-    explaining why discovery failed.
+    Returns the judge on success, or a human-readable reason string on failure.
     """
-    try:
-        import ollama as _ollama  # noqa: F401
-    except ImportError:
-        return "ollama package is not installed."
+    _API_KEY_ENV = {"anthropic": "ANTHROPIC_API_KEY", "openai": "OPENAI_API_KEY"}
 
-    import httpx
+    if provider == "ollama":
+        try:
+            import ollama as _ollama  # noqa: F401
+        except ImportError:
+            return "ollama package is not installed."
 
-    base_url = parse_ollama_host(os.environ.get("OLLAMA_HOST"))
-    try:
-        resp = httpx.get(f"{base_url}/api/tags", timeout=5)
-        resp.raise_for_status()
-        models = resp.json().get("models", [])
-        if not models:
-            return "Ollama is running but has no models installed."
-        available = {m["name"] for m in models}
-        requested = _resolve_model(OLLAMA_MODEL or "")
-        if requested and requested in available:
-            model_name = requested
-        elif requested and requested not in available:
-            return (
-                f"Requested Ollama model {requested!r} not found. "
-                f"Available: {', '.join(sorted(available))}."
-            )
-        else:
-            model_name = models[0]["name"]
-        return AnyLLMJudge(model_name, "ollama", api_base=base_url)
-    except Exception:
-        return f"Could not connect to Ollama at {base_url}."
+        base_url = parse_ollama_host(os.environ.get("OLLAMA_HOST"))
+        try:
+            models = get_ollama_models(base_url)
+            if not models:
+                return "Ollama is running but has no models installed."
+            available = {m["name"] for m in models}
+            if model and model in available:
+                return AnyLLMJudge(model, "ollama", api_base=base_url)
+            elif model and model not in available:
+                return (
+                    f"Ollama model {model!r} not found. Available: {', '.join(sorted(available))}."
+                )
+            else:
+                return AnyLLMJudge(models[0]["name"], "ollama", api_base=base_url)
+        except Exception:
+            return f"Could not connect to Ollama at {base_url}."
 
-
-def _discover_anthropic() -> AnyLLMJudge | str:
-    """Use Anthropic API if ANTHROPIC_API_KEY is set.
-
-    Returns an ``AnyLLMJudge`` on success, or a reason string on failure.
-    """
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        return "ANTHROPIC_API_KEY is not set."
-    model = _resolve_model(ANTHROPIC_MODEL)
-    return AnyLLMJudge(model, "anthropic", api_key=api_key)
-
-
-def _discover_openai() -> AnyLLMJudge | str:
-    """Use OpenAI API if OPENAI_API_KEY is set.
-
-    Returns an ``AnyLLMJudge`` on success, or a reason string on failure.
-    """
-    api_key = os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        return "OPENAI_API_KEY is not set."
-    model = _resolve_model(OPENAI_MODEL)
-    return AnyLLMJudge(model, "openai", api_key=api_key)
-
-
-def _default_judge_llm() -> JudgeLLM:
-    """Auto-discover an available LLM backend.
-
-    Controlled by PYTEST_LLM_RUBRIC_PROVIDER:
-      (unset)    - try Ollama only, skip if unavailable
-      auto       - try Ollama → Anthropic → OpenAI; fail if none found
-      ollama     - Ollama only; fail if unavailable
-      anthropic  - Anthropic API only; fail if unavailable
-      openai     - OpenAI API only; fail if unavailable
-      <other>    - pass provider + model to AnyLLMJudge (any-llm handles it)
-
-    Explicit providers fail (pytest.fail) instead of skip so that CI
-    misconfigurations surface as errors rather than silent skips.
-    """
-    provider = os.environ.get(ENV_PROVIDER, "").lower()
-
-    if provider == "openai":
-        result = _discover_openai()
-        if isinstance(result, AnyLLMJudge):
-            return result
-        pytest.fail(f"PYTEST_LLM_RUBRIC_PROVIDER=openai but {result}")
-
-    elif provider == "anthropic":
-        result = _discover_anthropic()
-        if isinstance(result, AnyLLMJudge):
-            return result
-        pytest.fail(f"PYTEST_LLM_RUBRIC_PROVIDER=anthropic but {result}")
-
-    elif provider == "ollama" or provider == "":
-        result = _discover_ollama()
-        if isinstance(result, AnyLLMJudge):
-            return result
-        if provider == "ollama":
-            pytest.fail(f"PYTEST_LLM_RUBRIC_PROVIDER=ollama but {result}")
-        pytest.skip(result)
-
-    elif provider == "auto":
-        reasons: list[str] = []
-        for name, discover in [
-            ("ollama", _discover_ollama),
-            ("anthropic", _discover_anthropic),
-            ("openai", _discover_openai),
-        ]:
-            result = discover()
-            if isinstance(result, AnyLLMJudge):
-                return result
-            reasons.append(f"  {name}: {result}")
-        pytest.fail("PYTEST_LLM_RUBRIC_PROVIDER=auto but no backend found.\n" + "\n".join(reasons))
+    elif key_env := _API_KEY_ENV.get(provider):
+        api_key = os.environ.get(key_env)
+        if not api_key:
+            return f"{key_env} is not set."
+        return AnyLLMJudge(model, provider, api_key=api_key)
 
     else:
-        model = os.environ.get(ENV_MODEL)
-        if not model:
-            pytest.fail(
-                f"PYTEST_LLM_RUBRIC_PROVIDER={provider!r} requires "
-                f"PYTEST_LLM_RUBRIC_MODEL to be set."
-            )
         return AnyLLMJudge(model, provider)
+
+
+def _resolve_auto_models(config: pytest.Config) -> list[str]:
+    """Resolve the auto-discovery model list.
+
+    Priority: env var > ini option > defaults.AUTO_MODELS.
+    """
+    env = os.environ.get(ENV_AUTO_MODELS, "").strip()
+    if env:
+        return [e.strip() for e in env.split(",") if e.strip()]
+
+    ini: list[str] = config.getini("llm_rubric_auto_models")
+    if ini:
+        return ini
+
+    return AUTO_MODELS
+
+
+def _default_judge_llm(config: pytest.Config) -> JudgeLLM:
+    """Build an LLM judge from ``PYTEST_LLM_RUBRIC_MODEL``.
+
+    The env var must be one of:
+      ``provider:model``  — e.g. ``anthropic:claude-haiku-4-5``
+      ``auto``            — try each model in the auto-discovery list
+
+    Raises ``pytest.fail`` when the requested backend cannot be reached.
+    """
+    raw = os.environ.get(ENV_MODEL, "").strip()
+
+    if not raw:
+        pytest.fail(
+            "PYTEST_LLM_RUBRIC_MODEL is not set. "
+            "Set it to 'provider:model' (e.g. 'anthropic:claude-haiku-4-5') "
+            "or 'auto' to try defaults."
+        )
+
+    if raw.lower() == "auto":
+        auto_models = _resolve_auto_models(config)
+        reasons: list[str] = []
+        for entry in auto_models:
+            provider, model = _parse_model(entry)
+            result = _make_judge(provider, model)
+            if isinstance(result, AnyLLMJudge):
+                if provider != "ollama":
+                    warnings.warn(
+                        f"PYTEST_LLM_RUBRIC_MODEL=auto: using cloud provider "
+                        f"'{provider}' ({model}). Test documents will be sent to "
+                        f"a third-party API. Set the model explicitly to suppress "
+                        f"this warning.",
+                        stacklevel=2,
+                    )
+                return result
+            reasons.append(f"  {entry}: {result}")
+        pytest.fail("PYTEST_LLM_RUBRIC_MODEL=auto but no backend found.\n" + "\n".join(reasons))
+
+    try:
+        provider, model = _parse_model(raw)
+    except ValueError as exc:
+        pytest.fail(str(exc))
+    result = _make_judge(provider, model)
+    if isinstance(result, AnyLLMJudge):
+        return result
+    pytest.fail(f"{raw}: {result}")
 
 
 def _preflight_or_skip(judge: JudgeLLM) -> JudgeLLM:
@@ -246,21 +263,31 @@ def _preflight_or_skip(judge: JudgeLLM) -> JudgeLLM:
             + "\n".join(
                 f"  {f['criterion']}: expected {f['expected']}, got {f['actual']}" for f in failures
             )
+            + "\nTry a larger model, or set PYTEST_LLM_RUBRIC_SKIP_PREFLIGHT=1 to bypass."
         )
         pytest.skip(msg)
     return judge
 
 
 @pytest.fixture(scope="session")
-def judge_llm() -> JudgeLLM:
+def judge_llm(request: pytest.FixtureRequest) -> JudgeLLM:
     """Provide an LLM backend for rubric judging.
 
     Override this fixture in your conftest.py to use a custom backend.
     Note: if overriding, use scope="session" to match the default scope.
     The backend is verified once per session via preflight golden tests.
     """
-    judge = _default_judge_llm()
+    judge = _default_judge_llm(request.config)
     return _preflight_or_skip(judge)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addini(
+        "llm_rubric_auto_models",
+        type="linelist",
+        default=[],
+        help="List of provider:model strings to try when PYTEST_LLM_RUBRIC_MODEL=auto.",
+    )
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/src/pytest_llm_rubric/utils.py
+++ b/src/pytest_llm_rubric/utils.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import ipaddress
 import urllib.parse
+from typing import Any
+
+import httpx
 
 OLLAMA_DEFAULT_HOST = "127.0.0.1"
 OLLAMA_DEFAULT_PORT = 11434
@@ -38,3 +41,10 @@ def parse_ollama_host(host: str | None) -> str:
         return f"{scheme}://{host}:{port}/{path}"
 
     return f"{scheme}://{host}:{port}"
+
+
+def get_ollama_models(base_url: str) -> list[dict[str, Any]]:
+    """Fetch the list of locally available Ollama models."""
+    resp = httpx.get(f"{base_url}/api/tags", timeout=5)
+    resp.raise_for_status()
+    return resp.json().get("models", [])

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -9,19 +9,50 @@ import pytest
 
 from pytest_llm_rubric.plugin import (
     AnyLLMJudge,
-    _discover_anthropic,
-    _discover_ollama,
-    _discover_openai,
+    _make_judge,
+    _parse_model,
 )
 
 # ---------------------------------------------------------------------------
-# Discovery tests
+# _parse_model tests
 # ---------------------------------------------------------------------------
 
 
-class TestDiscoverOllama:
-    def test_returns_reason_when_ollama_package_missing(self, monkeypatch):
-        """Should return a reason string when the ollama package is not importable."""
+class TestParseModel:
+    def test_anthropic_prefix(self):
+        assert _parse_model("anthropic:claude-haiku-4-5") == ("anthropic", "claude-haiku-4-5")
+
+    def test_ollama_prefix_with_tag(self):
+        """ollama:qwen3.5:9b → provider='ollama', model='qwen3.5:9b'."""
+        assert _parse_model("ollama:qwen3.5:9b") == ("ollama", "qwen3.5:9b")
+
+    def test_openai_prefix(self):
+        assert _parse_model("openai:gpt-4o") == ("openai", "gpt-4o")
+
+    def test_case_insensitive(self):
+        assert _parse_model("Anthropic:claude-haiku-4-5") == ("anthropic", "claude-haiku-4-5")
+
+    def test_no_colon_raises(self):
+        with pytest.raises(ValueError, match="Invalid model format"):
+            _parse_model("gpt-4o")
+
+    def test_unknown_prefix_raises(self):
+        with pytest.raises(ValueError, match="Unknown provider"):
+            _parse_model("mycompany:custom-model")
+
+    def test_bare_ollama_tag_raises(self):
+        """Bare 'qwen3.5:9b' has no known provider prefix → error."""
+        with pytest.raises(ValueError, match="Unknown provider"):
+            _parse_model("qwen3.5:9b")
+
+
+# ---------------------------------------------------------------------------
+# _make_judge tests
+# ---------------------------------------------------------------------------
+
+
+class TestMakeJudge:
+    def test_ollama_returns_reason_when_package_missing(self, monkeypatch):
         import builtins
         import importlib
 
@@ -33,61 +64,113 @@ class TestDiscoverOllama:
             return real_import(name, *args, **kwargs)
 
         monkeypatch.setattr(builtins, "__import__", _block_ollama)
-        # Clear cached import so the guard re-runs
         if "ollama" in importlib.sys.modules:
             monkeypatch.delitem(importlib.sys.modules, "ollama")
 
-        result = _discover_ollama()
+        result = _make_judge("ollama", "qwen3.5:9b")
         assert isinstance(result, str)
         assert "not installed" in result
 
-    def test_returns_judge_when_running(self):
-        result = _discover_ollama()
+    def test_ollama_returns_judge_when_running(self):
+        result = _make_judge("ollama", "")
         if isinstance(result, str):
             pytest.skip(f"Ollama is not running: {result}")
         assert isinstance(result, AnyLLMJudge)
 
-    def test_returns_reason_when_unreachable(self, monkeypatch):
+    def test_ollama_returns_reason_when_unreachable(self, monkeypatch):
         monkeypatch.setenv("OLLAMA_HOST", "http://localhost:19999")
-        result = _discover_ollama()
+        result = _make_judge("ollama", "qwen3.5:9b")
         assert isinstance(result, str)
         assert "Could not connect" in result
 
-    def test_returns_reason_when_model_not_found(self, monkeypatch):
-        """Requesting a non-existent model should return a reason, not silently substitute."""
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "nonexistent-model-xyz")
+    def test_ollama_returns_reason_when_model_not_found(self):
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"models": [{"name": "some-real-model:latest"}]}
         with patch("httpx.get", return_value=mock_resp):
-            result = _discover_ollama()
+            result = _make_judge("ollama", "nonexistent-model-xyz")
         assert isinstance(result, str)
         assert "not found" in result
 
-
-class TestDiscoverAnthropic:
-    def test_returns_reason_without_key(self, monkeypatch):
+    def test_anthropic_returns_reason_without_key(self, monkeypatch):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        result = _discover_anthropic()
+        result = _make_judge("anthropic", "claude-haiku-4-5")
         assert isinstance(result, str)
         assert "ANTHROPIC_API_KEY" in result
 
-    def test_returns_judge_with_key(self, monkeypatch):
+    def test_anthropic_returns_judge_with_key(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
-        judge = _discover_anthropic()
+        judge = _make_judge("anthropic", "claude-haiku-4-5")
         assert isinstance(judge, AnyLLMJudge)
 
-
-class TestDiscoverOpenAI:
-    def test_returns_reason_without_key(self, monkeypatch):
+    def test_openai_returns_reason_without_key(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        result = _discover_openai()
+        result = _make_judge("openai", "gpt-4o")
         assert isinstance(result, str)
         assert "OPENAI_API_KEY" in result
 
-    def test_returns_judge_with_key(self, monkeypatch):
+    def test_openai_returns_judge_with_key(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-        judge = _discover_openai()
+        judge = _make_judge("openai", "gpt-4o")
         assert isinstance(judge, AnyLLMJudge)
+
+    def test_passthrough_provider_returns_judge(self):
+        judge = _make_judge("groq", "llama-3.3-70b")
+        assert isinstance(judge, AnyLLMJudge)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_auto_models tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAutoModels:
+    def test_env_var_takes_priority(self, pytester, monkeypatch):
+        """PYTEST_LLM_RUBRIC_AUTO_MODELS env var wins over ini and defaults."""
+        monkeypatch.setenv(
+            "PYTEST_LLM_RUBRIC_AUTO_MODELS",
+            "anthropic:claude-haiku-4-5, openai:gpt-4o",
+        )
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "auto")
+        monkeypatch.setenv("OLLAMA_HOST", "http://localhost:19999")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("PYTHONUTF8", "1")
+        pytester.makeconftest("")
+        pytester.makepyfile("""
+            def test_uses_judge(judge_llm):
+                assert judge_llm is not None
+        """)
+        result = pytester.runpytest_subprocess("-v")
+        result.assert_outcomes(errors=1)
+        # Should only try the two models from env var, not the defaults.
+        result.stdout.fnmatch_lines(
+            [
+                "*anthropic:claude-haiku-4-5: ANTHROPIC_API_KEY*",
+                "*openai:gpt-4o: OPENAI_API_KEY*",
+            ]
+        )
+        # Failure reasons should NOT include an ollama entry (not in the custom list).
+        result.stdout.no_fnmatch_line("*ollama:*")
+
+    def test_ini_option_over_defaults(self, pytester, monkeypatch):
+        """ini option wins over defaults.AUTO_MODELS."""
+        monkeypatch.delenv("PYTEST_LLM_RUBRIC_AUTO_MODELS", raising=False)
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "auto")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("PYTHONUTF8", "1")
+        pytester.makeini("""
+            [pytest]
+            llm_rubric_auto_models =
+                anthropic:claude-haiku-4-5
+        """)
+        pytester.makeconftest("")
+        pytester.makepyfile("""
+            def test_uses_judge(judge_llm):
+                assert judge_llm is not None
+        """)
+        result = pytester.runpytest_subprocess("-v")
+        result.assert_outcomes(errors=1)
+        result.stdout.fnmatch_lines(["*anthropic*ANTHROPIC_API_KEY*"])
 
 
 # ---------------------------------------------------------------------------
@@ -261,31 +344,31 @@ def judge_llm():
 
 
 class TestJudgeLLMFixture:
-    def test_skip_when_no_backend(self, pytester, monkeypatch):
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "")
-        monkeypatch.setenv("OLLAMA_HOST", "http://localhost:19999")
-        pytester.makeconftest("")
-        pytester.makepyfile("""
-            def test_uses_judge(judge_llm):
-                assert judge_llm is not None
-        """)
-        result = pytester.runpytest_subprocess("-v", "-rs")
-        result.assert_outcomes(skipped=1)
-        result.stdout.fnmatch_lines(["*Could not connect to Ollama*"])
-
-    def test_default_backend_ignores_api_keys(self, pytester, monkeypatch):
-        """Default (empty) backend must use Ollama only, even when paid API keys are present."""
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "")
-        monkeypatch.setenv("OLLAMA_HOST", "http://localhost:19999")
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-should-not-be-used")
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-should-not-be-used")
+    def test_fails_when_model_not_set(self, pytester, monkeypatch):
+        """MODEL must be set — no silent default."""
+        monkeypatch.delenv("PYTEST_LLM_RUBRIC_MODEL", raising=False)
+        monkeypatch.setenv("PYTHONUTF8", "1")
         pytester.makeconftest("")
         pytester.makepyfile("""
             def test_uses_judge(judge_llm):
                 assert judge_llm is not None
         """)
         result = pytester.runpytest_subprocess("-v")
-        result.assert_outcomes(skipped=1)
+        result.assert_outcomes(errors=1)
+        result.stdout.fnmatch_lines(["*PYTEST_LLM_RUBRIC_MODEL*not set*"])
+
+    def test_fails_on_invalid_model_format(self, pytester, monkeypatch):
+        """Invalid model string should produce a clear error, not a traceback."""
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "qwen3.5:9b")
+        monkeypatch.setenv("PYTHONUTF8", "1")
+        pytester.makeconftest("")
+        pytester.makepyfile("""
+            def test_uses_judge(judge_llm):
+                assert judge_llm is not None
+        """)
+        result = pytester.runpytest_subprocess("-v")
+        result.assert_outcomes(errors=1)
+        result.stdout.fnmatch_lines(["*Unknown provider*"])
 
     def test_override_fixture(self, pytester):
         pytester.makeconftest(_FAKE_JUDGE_CONFTEST)
@@ -298,7 +381,7 @@ class TestJudgeLLMFixture:
         result.assert_outcomes(passed=1)
 
     def test_explicit_ollama_fails_when_unavailable(self, pytester, monkeypatch):
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "ollama")
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "ollama:qwen3.5:9b")
         monkeypatch.setenv("OLLAMA_HOST", "http://localhost:19999")
         monkeypatch.setenv("PYTHONUTF8", "1")
         pytester.makeconftest("")
@@ -310,7 +393,7 @@ class TestJudgeLLMFixture:
         result.assert_outcomes(errors=1)
 
     def test_explicit_openai_fails_without_key(self, pytester, monkeypatch):
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "openai")
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "openai:gpt-4o")
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.setenv("PYTHONUTF8", "1")
         pytester.makeconftest("")
@@ -322,7 +405,7 @@ class TestJudgeLLMFixture:
         result.assert_outcomes(errors=1)
 
     def test_explicit_anthropic_fails_without_key(self, pytester, monkeypatch):
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "anthropic")
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "anthropic:claude-haiku-4-5")
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("PYTHONUTF8", "1")
         pytester.makeconftest("")
@@ -333,9 +416,9 @@ class TestJudgeLLMFixture:
         result = pytester.runpytest_subprocess("-v")
         result.assert_outcomes(errors=1)
 
-    def test_auto_backend_fails_with_reasons(self, pytester, monkeypatch):
+    def test_auto_fails_with_reasons(self, pytester, monkeypatch):
         """Auto mode should list per-provider reasons when all backends fail."""
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "auto")
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "auto")
         monkeypatch.setenv("OLLAMA_HOST", "http://localhost:19999")
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -349,34 +432,70 @@ class TestJudgeLLMFixture:
         result.assert_outcomes(errors=1)
         result.stdout.fnmatch_lines(
             [
-                "*ollama: Could not connect*",
-                "*anthropic: ANTHROPIC_API_KEY*",
-                "*openai: OPENAI_API_KEY*",
+                "*ollama:*",
+                "*anthropic:*ANTHROPIC_API_KEY*",
+                "*openai:*OPENAI_API_KEY*",
             ]
         )
 
-    def test_passthrough_provider_requires_model(self, pytester, monkeypatch):
-        """Passthrough providers must have PYTEST_LLM_RUBRIC_MODEL set."""
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "groq")
-        monkeypatch.delenv("PYTEST_LLM_RUBRIC_MODEL", raising=False)
+    def test_auto_warns_on_cloud_fallback(self, pytester, monkeypatch):
+        """When auto falls through to a cloud provider, a warning should be emitted."""
+        monkeypatch.setenv(
+            "PYTEST_LLM_RUBRIC_AUTO_MODELS",
+            "anthropic:claude-haiku-4-5",
+        )
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "auto")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_SKIP_PREFLIGHT", "1")
         monkeypatch.setenv("PYTHONUTF8", "1")
         pytester.makeconftest("")
         pytester.makepyfile("""
             def test_uses_judge(judge_llm):
                 assert judge_llm is not None
         """)
-        result = pytester.runpytest_subprocess("-v")
-        result.assert_outcomes(errors=1)
-        result.stdout.fnmatch_lines(["*requires*PYTEST_LLM_RUBRIC_MODEL*"])
+        result = pytester.runpytest_subprocess("-v", "-W", "all")
+        result.assert_outcomes(passed=1)
+        result.stdout.fnmatch_lines(["*cloud provider*anthropic*third-party API*"])
+
+    def test_preflight_failure_includes_action(self, pytester, monkeypatch):
+        """Preflight failure message should tell the user what to do next."""
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "groq:llama-3.3-70b")
+        monkeypatch.setenv("PYTHONUTF8", "1")
+        monkeypatch.delenv("PYTEST_LLM_RUBRIC_SKIP_PREFLIGHT", raising=False)
+        # Provide a conftest that patches preflight to always fail,
+        # but lets the real _preflight_or_skip format the message.
+        pytester.makeconftest("""
+import pytest
+from unittest.mock import patch
+from pytest_llm_rubric.plugin import AnyLLMJudge, _preflight_or_skip
+from pytest_llm_rubric.preflight import PreflightResult
+
+@pytest.fixture(scope="session")
+def judge_llm():
+    judge = AnyLLMJudge("fake", "groq")
+    fake_result = PreflightResult(
+        passed=False,
+        correct=4,
+        total=12,
+        stopped_early=True,
+        details=[
+            {"criterion": "test", "expected": "PASS", "actual": "FAIL", "correct": False},
+        ],
+    )
+    with patch("pytest_llm_rubric.plugin.preflight", return_value=fake_result):
+        return _preflight_or_skip(judge)
+        """)
+        pytester.makepyfile("""
+            def test_uses_judge(judge_llm):
+                assert judge_llm is not None
+        """)
+        result = pytester.runpytest_subprocess("-v", "-rs")
+        result.assert_outcomes(skipped=1)
+        result.stdout.fnmatch_lines(["*PYTEST_LLM_RUBRIC_SKIP_PREFLIGHT*"])
 
     def test_passthrough_provider_creates_judge(self, pytester, monkeypatch):
-        """Passthrough provider + model creates AnyLLMJudge without calling the LLM.
-
-        Groq SDK is not installed, but discovery only constructs the object.
-        SKIP_PREFLIGHT=1 avoids an actual completion() call.
-        """
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_PROVIDER", "groq")
-        monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "llama-3.3-70b-versatile")
+        """groq:model creates AnyLLMJudge via passthrough."""
+        monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "groq:llama-3.3-70b-versatile")
         monkeypatch.setenv("PYTEST_LLM_RUBRIC_SKIP_PREFLIGHT", "1")
         monkeypatch.setenv("PYTHONUTF8", "1")
         pytester.makeconftest("")
@@ -420,7 +539,7 @@ class TestJudgeLLMFixture:
 @pytest.mark.integration
 class TestIntegration:
     def test_ollama_complete(self):
-        result = _discover_ollama()
+        result = _make_judge("ollama", "")
         if isinstance(result, str):
             pytest.skip(f"Ollama is not running: {result}")
         judge = result
@@ -434,7 +553,7 @@ class TestIntegration:
     def test_anthropic_complete(self):
         if not os.environ.get("ANTHROPIC_API_KEY"):
             pytest.skip("ANTHROPIC_API_KEY not set")
-        result = _discover_anthropic()
+        result = _make_judge("anthropic", "claude-haiku-4-5")
         assert isinstance(result, AnyLLMJudge)
         response = result.complete(
             [
@@ -446,7 +565,7 @@ class TestIntegration:
     def test_openai_complete(self):
         if not os.environ.get("OPENAI_API_KEY"):
             pytest.skip("OPENAI_API_KEY not set")
-        result = _discover_openai()
+        result = _make_judge("openai", "gpt-5.4-nano")
         assert isinstance(result, AnyLLMJudge)
         response = result.complete(
             [


### PR DESCRIPTION
## Summary

- Replace `PYTEST_LLM_RUBRIC_PROVIDER` + `PYTEST_LLM_RUBRIC_MODEL` with a single `PYTEST_LLM_RUBRIC_MODEL` using `provider:model` syntax (e.g. `anthropic:claude-haiku-4-5`, `ollama:qwen3.5:9b`)
- Follows the [any-llm-sdk](https://github.com/mozilla-ai/any-llm) colon-separator convention
- Adds `auto` mode with configurable fallback list (`PYTEST_LLM_RUBRIC_AUTO_MODELS` env var / `llm_rubric_auto_models` ini option)
- Emits a warning when `auto` falls through to a cloud provider (data privacy)
- Preflight failure messages now include actionable next steps

### Breaking changes

- `PYTEST_LLM_RUBRIC_PROVIDER` is removed
- `PYTEST_LLM_RUBRIC_MODEL` now requires `provider:` prefix
- Unset `MODEL` is an error (no silent Ollama-only default)

### Motivation

Switching providers (e.g. Ollama → Anthropic) required changing two env vars. Forgetting to update the model name would send an Ollama model name to a cloud API, causing confusing failures.

## Test plan

- [x] 99 unit tests passed (including new tests for `_parse_model`, `_make_judge`, `_resolve_auto_models`, cloud warning, preflight action message, invalid format error)
- [x] 3 integration tests passed (Ollama, Anthropic, OpenAI)
- [x] ruff check, ruff format, ty check all passed
- [x] Manual smoke test with `PYTEST_LLM_RUBRIC_MODEL=auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
