### PR TITLE
Show preflight duration in test output

### DIFF
--- a/src/pytest_llm_rubric/plugin.py
+++ b/src/pytest_llm_rubric/plugin.py
@@ -18,6 +18,8 @@ ENV_MODEL = "PYTEST_LLM_RUBRIC_MODEL"
 ENV_AUTO_MODELS = "PYTEST_LLM_RUBRIC_AUTO_MODELS"
 ENV_SKIP_PREFLIGHT = "PYTEST_LLM_RUBRIC_SKIP_PREFLIGHT"
 
+_preflight_stash_key: pytest.StashKey[str] = pytest.StashKey()
+
 
 @functools.cache
 def _get_known_providers() -> frozenset[str]:
@@ -250,7 +252,7 @@ def _default_judge_llm(config: pytest.Config) -> JudgeLLM:
     pytest.fail(f"{raw}: {result}")
 
 
-def _preflight_or_skip(judge: JudgeLLM) -> JudgeLLM:
+def _preflight_or_skip(judge: JudgeLLM, config: pytest.Config | None = None) -> JudgeLLM:
     """Run preflight check and skip if the backend is unreliable."""
     if os.environ.get(ENV_SKIP_PREFLIGHT, "").lower() in ("1", "true", "yes"):
         return judge
@@ -270,10 +272,9 @@ def _preflight_or_skip(judge: JudgeLLM) -> JudgeLLM:
             + "\nTry a larger model, or set PYTEST_LLM_RUBRIC_SKIP_PREFLIGHT=1 to bypass."
         )
         pytest.skip(msg)
-    warnings.warn(
-        f"preflight passed ({result.correct}/{result.total}) in {elapsed:.1f}s",
-        stacklevel=2,
-    )
+    summary = f"preflight passed ({result.correct}/{result.total}) in {elapsed:.1f}s"
+    if config is not None:
+        config.stash[_preflight_stash_key] = summary
     return judge
 
 
@@ -286,7 +287,7 @@ def judge_llm(request: pytest.FixtureRequest) -> JudgeLLM:
     The backend is verified once per session via preflight golden tests.
     """
     judge = _default_judge_llm(request.config)
-    return _preflight_or_skip(judge)
+    return _preflight_or_skip(judge, config=request.config)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -311,3 +312,12 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     for item in items:
         if "judge_llm" in getattr(item, "fixturenames", ()):
             item.add_marker(marker)
+
+
+def pytest_terminal_summary(
+    terminalreporter: pytest.TerminalReporter, config: pytest.Config
+) -> None:
+    summary = config.stash.get(_preflight_stash_key, None)
+    if summary is not None:
+        terminalreporter.section("LLM Rubric")
+        terminalreporter.line(summary)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -458,7 +458,7 @@ class TestJudgeLLMFixture:
         result.stdout.fnmatch_lines(["*cloud provider*anthropic*third-party API*"])
 
     def test_preflight_timing_in_output(self, pytester, monkeypatch):
-        """Preflight pass message should include elapsed time."""
+        """Preflight pass message should include elapsed time in terminal summary."""
         monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "groq:llama-3.3-70b")
         monkeypatch.setenv("PYTHONUTF8", "1")
         monkeypatch.delenv("PYTEST_LLM_RUBRIC_SKIP_PREFLIGHT", raising=False)
@@ -469,7 +469,7 @@ from pytest_llm_rubric.plugin import AnyLLMJudge, _preflight_or_skip
 from pytest_llm_rubric.preflight import PreflightResult
 
 @pytest.fixture(scope="session")
-def judge_llm():
+def judge_llm(request):
     judge = AnyLLMJudge("fake", "groq")
     fake_result = PreflightResult(
         passed=True,
@@ -479,18 +479,18 @@ def judge_llm():
         details=[],
     )
     with patch("pytest_llm_rubric.plugin.preflight", return_value=fake_result):
-        return _preflight_or_skip(judge)
+        return _preflight_or_skip(judge, config=request.config)
         """)
         pytester.makepyfile("""
             def test_uses_judge(judge_llm):
                 assert judge_llm is not None
         """)
-        result = pytester.runpytest_subprocess("-v", "-W", "all")
+        result = pytester.runpytest_subprocess("-v")
         result.assert_outcomes(passed=1)
-        result.stdout.fnmatch_lines(["*preflight passed*12*in*s*"])
+        result.stdout.fnmatch_lines(["*LLM Rubric*", "*preflight passed*12*in*s*"])
 
     def test_preflight_failure_timing_in_output(self, pytester, monkeypatch):
-        """Preflight failure message should include elapsed time."""
+        """Preflight failure skip message should include elapsed time."""
         monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "groq:llama-3.3-70b")
         monkeypatch.setenv("PYTHONUTF8", "1")
         monkeypatch.delenv("PYTEST_LLM_RUBRIC_SKIP_PREFLIGHT", raising=False)
@@ -501,7 +501,7 @@ from pytest_llm_rubric.plugin import AnyLLMJudge, _preflight_or_skip
 from pytest_llm_rubric.preflight import PreflightResult
 
 @pytest.fixture(scope="session")
-def judge_llm():
+def judge_llm(request):
     judge = AnyLLMJudge("fake", "groq")
     fake_result = PreflightResult(
         passed=False,
@@ -513,7 +513,7 @@ def judge_llm():
         ],
     )
     with patch("pytest_llm_rubric.plugin.preflight", return_value=fake_result):
-        return _preflight_or_skip(judge)
+        return _preflight_or_skip(judge, config=request.config)
         """)
         pytester.makepyfile("""
             def test_uses_judge(judge_llm):


### PR DESCRIPTION
## Summary
- Measure wall time around the `preflight()` call using `time.monotonic()` in `_preflight_or_skip`
- Include elapsed seconds in the success warning message (e.g. `preflight passed (12/12) in 142.3s`)
- Include elapsed seconds in the failure skip message (e.g. `failed preflight (4/12) in 8.1s`)
- Add two pytester tests verifying timing appears in both pass and fail output

Closes #34

## Test plan
- [x] `uv run pytest -m "not integration" -x` passes (101 tests)
- [x] `uv run ruff check src/ tests/` passes
- [x] `uv run ruff format src/ tests/` — no changes needed
- [x] Pre-commit hooks (ruff, ty, pytest) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
