### PR TITLE
Fall back to auto when llm_rubric_auto_models is set in ini

### DIFF
--- a/src/pytest_llm_rubric/plugin.py
+++ b/src/pytest_llm_rubric/plugin.py
@@ -214,11 +214,17 @@ def _default_judge_llm(config: pytest.Config) -> JudgeLLM:
     raw = os.environ.get(ENV_MODEL, "").strip()
 
     if not raw:
-        pytest.fail(
-            "PYTEST_LLM_RUBRIC_MODEL is not set. "
-            "Set it to 'provider:model' (e.g. 'anthropic:claude-haiku-4-5') "
-            "or 'auto' to try defaults."
-        )
+        # Fall back to auto when the user configured models via ini option.
+        ini: list[str] = config.getini("llm_rubric_auto_models")
+        if ini:
+            raw = "auto"
+        else:
+            pytest.fail(
+                "PYTEST_LLM_RUBRIC_MODEL is not set. "
+                "Set it to 'provider:model' (e.g. 'anthropic:claude-haiku-4-5'), "
+                "'auto' to try defaults, or configure llm_rubric_auto_models in "
+                "your pyproject.toml [tool.pytest.ini_options]."
+            )
 
     if raw.lower() == "auto":
         auto_models = _resolve_auto_models(config)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -357,6 +357,31 @@ class TestJudgeLLMFixture:
         result.assert_outcomes(errors=1)
         result.stdout.fnmatch_lines(["*PYTEST_LLM_RUBRIC_MODEL*not set*"])
 
+    def test_falls_back_to_auto_when_ini_set(self, pytester, monkeypatch):
+        """When env var is unset but llm_rubric_auto_models is in ini, treat as auto."""
+        monkeypatch.delenv("PYTEST_LLM_RUBRIC_MODEL", raising=False)
+        monkeypatch.delenv("PYTEST_LLM_RUBRIC_AUTO_MODELS", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("PYTHONUTF8", "1")
+        pytester.makeini("""
+            [pytest]
+            llm_rubric_auto_models =
+                anthropic:claude-haiku-4-5
+        """)
+        pytester.makeconftest("")
+        pytester.makepyfile("""
+            def test_uses_judge(judge_llm):
+                assert judge_llm is not None
+        """)
+        result = pytester.runpytest_subprocess("-v")
+        # Should enter auto mode (not error about MODEL not set).
+        # It will fail because no backend is reachable, but the error should
+        # mention the auto-discovery models, not "PYTEST_LLM_RUBRIC_MODEL is not set".
+        result.assert_outcomes(errors=1)
+        result.stdout.fnmatch_lines(["*anthropic*ANTHROPIC_API_KEY*"])
+        # The failure should be "auto but no backend found", not "not set".
+        result.stdout.fnmatch_lines(["*auto but no backend found*"])
+
     def test_fails_on_invalid_model_format(self, pytester, monkeypatch):
         """Invalid model string should produce a clear error, not a traceback."""
         monkeypatch.setenv("PYTEST_LLM_RUBRIC_MODEL", "qwen3.5:9b")


### PR DESCRIPTION
## Summary

- When `PYTEST_LLM_RUBRIC_MODEL` env var is unset/empty but `llm_rubric_auto_models` is configured in ini options (e.g. `pyproject.toml`), fall back to auto mode instead of erroring
- Updated error message to mention `llm_rubric_auto_models` ini option as an alternative configuration method
- Added test case verifying the ini-based auto fallback works correctly

Closes #33

## Test plan

- [x] New test `test_falls_back_to_auto_when_ini_set` verifies that when env var is unset but ini has models configured, the plugin enters auto mode (not the "not set" error)
- [x] All 100 existing non-integration tests pass
- [x] Linting passes (`ruff check`)

Generated with [Claude Code](https://claude.com/claude-code)
